### PR TITLE
ステージ生成後にNavmeshをbakeする機能実装

### DIFF
--- a/Assets/Resources/Prefab/Stage.prefab
+++ b/Assets/Resources/Prefab/Stage.prefab
@@ -9,9 +9,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7572188163617921690}
+  - component: {fileID: 65341568056243617}
   m_Layer: 0
   m_Name: InSideWall
-  m_TagString: Untagged
+  m_TagString: Stage
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -31,6 +32,25 @@ Transform:
   m_Father: {fileID: 7712768426329541612}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &65341568056243617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 215056969595494429}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e3fdca004f2d45fe8abbed571a8abd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideArea: 0
+  m_Area: 0
+  m_OverrideGenerateLinks: 0
+  m_GenerateLinks: 0
+  m_IgnoreFromBuild: 0
+  m_ApplyToChildren: 1
+  m_AffectedAgents: ffffffff
 --- !u!1 &1744168106335570809
 GameObject:
   m_ObjectHideFlags: 0
@@ -40,9 +60,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3148873274185282483}
+  - component: {fileID: 2088915178731630811}
   m_Layer: 0
   m_Name: OutSideWall
-  m_TagString: Untagged
+  m_TagString: Stage
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -62,6 +83,25 @@ Transform:
   m_Father: {fileID: 7712768426329541612}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2088915178731630811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744168106335570809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e3fdca004f2d45fe8abbed571a8abd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideArea: 0
+  m_Area: 0
+  m_OverrideGenerateLinks: 0
+  m_GenerateLinks: 0
+  m_IgnoreFromBuild: 0
+  m_ApplyToChildren: 1
+  m_AffectedAgents: ffffffff
 --- !u!1 &1938581473151959162
 GameObject:
   m_ObjectHideFlags: 0
@@ -71,9 +111,11 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5426741166089954673}
+  - component: {fileID: 6417858501326136170}
+  - component: {fileID: 4421430593530188626}
   m_Layer: 0
   m_Name: Floor
-  m_TagString: Untagged
+  m_TagString: Stage
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -93,6 +135,56 @@ Transform:
   m_Father: {fileID: 7712768426329541612}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6417858501326136170
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938581473151959162}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a5ac11cc976e418e8d13136b07e1f52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AgentTypeID: 0
+  m_CollectObjects: 3
+  m_Size: {x: 10, y: 10, z: 10}
+  m_Center: {x: 0, y: 2, z: 0}
+  m_LayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_UseGeometry: 0
+  m_DefaultArea: 0
+  m_GenerateLinks: 0
+  m_IgnoreNavMeshAgent: 1
+  m_IgnoreNavMeshObstacle: 1
+  m_OverrideTileSize: 0
+  m_TileSize: 256
+  m_OverrideVoxelSize: 0
+  m_VoxelSize: 0.16666667
+  m_MinRegionArea: 2
+  m_NavMeshData: {fileID: 23800000, guid: f592bfe197b084f44a6f3b0225d7dfdc, type: 2}
+  m_BuildHeightMesh: 0
+--- !u!114 &4421430593530188626
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938581473151959162}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e3fdca004f2d45fe8abbed571a8abd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideArea: 0
+  m_Area: 0
+  m_OverrideGenerateLinks: 0
+  m_GenerateLinks: 0
+  m_IgnoreFromBuild: 0
+  m_ApplyToChildren: 1
+  m_AffectedAgents: ffffffff
 --- !u!1 &4998191480817402690
 GameObject:
   m_ObjectHideFlags: 0
@@ -102,9 +194,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3919837908161370143}
+  - component: {fileID: 293715501305846946}
   m_Layer: 0
   m_Name: Room
-  m_TagString: Untagged
+  m_TagString: Stage
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -124,6 +217,25 @@ Transform:
   m_Father: {fileID: 7712768426329541612}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &293715501305846946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4998191480817402690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e3fdca004f2d45fe8abbed571a8abd5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_OverrideArea: 0
+  m_Area: 0
+  m_OverrideGenerateLinks: 0
+  m_GenerateLinks: 0
+  m_IgnoreFromBuild: 0
+  m_ApplyToChildren: 1
+  m_AffectedAgents: ffffffff
 --- !u!1 &6624500817061936141
 GameObject:
   m_ObjectHideFlags: 0
@@ -203,7 +315,7 @@ GameObject:
   - component: {fileID: 3749939161639175603}
   m_Layer: 0
   m_Name: SecondFloor
-  m_TagString: Untagged
+  m_TagString: Stage
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -5,6 +5,8 @@ using Cysharp.Threading.Tasks;
 using System.Threading;
 using Scenes.Ingame.Manager;
 using Scenes.Ingame.InGameSystem;
+using Unity.AI;
+using Unity.AI.Navigation;
 
 namespace Scenes.Ingame.Stage
 {
@@ -82,6 +84,7 @@ namespace Scenes.Ingame.Stage
             if (viewDebugLog) DebugStageData(_stageGenerateData);
             await GenerateStage(token);
             await GenerateWall(token);
+            floorObject.GetComponent<NavMeshSurface>().BuildNavMesh();
             IngameManager.Instance.SetReady(ReadyEnum.StageReady);//ステージ生成完了を通知
         }
         private void InitialSet()


### PR DESCRIPTION
## 概要
<!--
追加した機能について記入してください。
-->
ステージ生成後にNavMeshSurfaceからBakeする機能実装
![ステージBakeイメージ](https://github.com/InnovaGameCreate/mythos-encounter/assets/67269447/1d99f6ea-267e-408b-87a3-5f86dfc70fb5)

## 変更点
<!--
変更した箇所について記入してください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
 - NavMeshSurfaceのアタッチ
 - ステージ生成後にNavMeshSurfaceからBakeする機能実装
## テスト
<!--
プッシュする前に下記のことを確認したかを確かめてください。確認した場合はチェックを付けてください。
※チェックの付け方 []を[x]とする。
-->
 - [] 複雑であったり、わかりにくい部分のコメントアウトでの説明
 - [x] 命名規則の統一
 - [x] 変更箇所にエラーが発生してるかの確認
 - [] ビルドが成功するかの確認
 
## 問題
<!--
現状なにか問題が発生している場合はこちらに書いてください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
