### PR TITLE
InGameシーンでエネミーが動くようにし、スポーン直後のPlayerに接近しないようにした 

### DIFF
--- a/Assets/Scenes/InGame.unity
+++ b/Assets/Scenes/InGame.unity
@@ -123,59 +123,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &289217649
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 289217651}
-  - component: {fileID: 289217650}
-  m_Layer: 0
-  m_Name: EnemySpowner
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &289217650
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 289217649}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b3495d4e27afa60438173cb613954761, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _debugMode: 0
-  _nonInGameManagerMode: 0
-  _enemyVisibilityMap: {fileID: 0}
-  _x: 0
-  _z: 0
-  _range: 0
-  _maxVisiviilityRange: 0
-  _centerPosition: {x: 0, y: 0, z: 0}
-  _testEnemy: {fileID: 0}
---- !u!4 &289217651
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 289217649}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -24.309069, y: 3.8078256, z: -19.88662}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &297431089
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -186,7 +133,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1112883371461353447, guid: aa4b384afbf5b184f8c221ba17895c92, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 1112883371461353447, guid: aa4b384afbf5b184f8c221ba17895c92, type: 3}
       propertyPath: m_LocalPosition.x
@@ -273,6 +220,7 @@ GameObject:
   m_Component:
   - component: {fileID: 385755861}
   - component: {fileID: 385755860}
+  - component: {fileID: 385755862}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -357,6 +305,29 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &385755862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 385755859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
 --- !u!1001 &579781216
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -371,7 +342,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7712768426329541612, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 7712768426329541612, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -489,7 +460,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1264538519
 GameObject:
@@ -842,7 +813,7 @@ PrefabInstance:
       objectReference: {fileID: 1846564571}
     - target: {fileID: 7052893467612382858, guid: 50bdab7d98cd7e74a8fbc46f11327523, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7052893467612382858, guid: 50bdab7d98cd7e74a8fbc46f11327523, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1027,6 +998,71 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6f9b1ceb957ddf84180c6db53f917a72, type: 3}
+--- !u!1001 &2025839412
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2356478341575929910, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_Name
+      value: EnemySpowner (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2356478341575929910, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -24.309069
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.8078256
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.88662
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7736650679182576676, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bba2b43ed544a404ba6e0b9ccad16846, type: 3}
 --- !u!1001 &5737438665223900935
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1114,7 +1150,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5926375678981222453, guid: f7a1c40a23d693246a50a7ddde897bec, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5926375678981222453, guid: f7a1c40a23d693246a50a7ddde897bec, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Scripts/Scenes/InGame/Enemy/EnemySearch.cs
+++ b/Assets/Scripts/Scenes/InGame/Enemy/EnemySearch.cs
@@ -187,5 +187,6 @@ namespace Scenes.Ingame.Enemy
             }
         }
 
+
     }
 }

--- a/Assets/Scripts/Scenes/InGame/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Scenes/InGame/Enemy/EnemySpawner.cs
@@ -56,7 +56,8 @@ namespace Scenes.Ingame.Enemy
         // Start is called before the first frame update
         void Start()
         {
-            if (_nonInGameManagerMode) {
+            if (_nonInGameManagerMode)
+            {
                 //マップをスキャン
                 _enemyVisibilityMap = new EnemyVisibilityMap();
                 _enemyVisibilityMap.debugMode = _debugMode;
@@ -67,6 +68,9 @@ namespace Scenes.Ingame.Enemy
                 //テストとしてここでEnemy制作を依頼している
                 EnemySpawn(EnemyName.TestEnemy, new Vector3(-10, _centerPosition.y + 3, -10));
 
+            }
+            else {
+                IngameManager.Instance.OnInitial.Subscribe(_ => InitialSpawn());
             }
 
             if (Instance == null)

--- a/Assets/Scripts/Scenes/InGame/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Scenes/InGame/Enemy/EnemySpawner.cs
@@ -49,6 +49,7 @@ namespace Scenes.Ingame.Enemy
         [SerializeField] private GameObject _MiGo;
 
 
+
         [Header("ê∂ê¨Ç∑ÇÈç€ÇÃê›íË")]
         [SerializeField] private Vector3 _enemySpawnPosition;
 

--- a/Assets/Scripts/Scenes/InGame/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Scenes/InGame/Enemy/EnemySpawner.cs
@@ -1,7 +1,13 @@
+using Scenes.Ingame.Manager;
+using Scenes.Ingame.Player;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
+using UniRx;
+using Scenes.Ingame.Manager;
+using Scenes.Ingame.InGameSystem;
+
 
 
 namespace Scenes.Ingame.Enemy
@@ -11,21 +17,29 @@ namespace Scenes.Ingame.Enemy
     /// </summary>
     public class EnemySpawner : MonoBehaviour
     {
+        public static EnemySpawner Instance;
+
         [Header("デバッグするかどうか")]
         [SerializeField] private bool _debugMode;
         [SerializeField][Tooltip("InGameManager無しで機能させるかどうか")] private bool _nonInGameManagerMode;
         [SerializeField][Tooltip("デバッグ時に作成する敵")]private EnemyName _enemyName;
 
+        [Header("マップの設定")]
         [Header("スキャンするマップに関して")]
         [SerializeField]
+        [Tooltip("自動で生成されるので挿入しない事")]
         private EnemyVisibilityMap _enemyVisibilityMap;
         [SerializeField]
+        [Tooltip("各マス目の数")]
         private byte _x, _z;
         [SerializeField]
+        [Tooltip("マップのマス目の幅")]
         private float _range;
         [SerializeField]
+        [Tooltip("最も視界の長い敵の視界の距離")]
         private float _maxVisiviilityRange;
         [SerializeField]
+        [Tooltip("マップのマス目の最も左下のマス目の中心部")]
         private Vector3 _centerPosition;
 
         [Header("作成する敵のプレハブ一覧")]
@@ -35,9 +49,34 @@ namespace Scenes.Ingame.Enemy
         [SerializeField] private GameObject _MiGo;
 
 
+        [Header("生成する際の設定")]
+        [SerializeField] private Vector3 _enemySpawnPosition;
+
         // Start is called before the first frame update
         void Start()
         {
+            if (_nonInGameManagerMode) {
+                //マップをスキャン
+                _enemyVisibilityMap = new EnemyVisibilityMap();
+                _enemyVisibilityMap.debugMode = _debugMode;
+                _enemyVisibilityMap.maxVisivilityRange = _maxVisiviilityRange;
+                _enemyVisibilityMap.GridMake(_x, _z, _range, _centerPosition);
+                _enemyVisibilityMap.MapScan();
+
+                //テストとしてここでEnemy制作を依頼している
+                EnemySpawn(EnemyName.TestEnemy, new Vector3(-10, _centerPosition.y + 3, -10));
+
+            }
+
+            if (Instance == null)
+                Instance = this;
+            else
+                Destroy(this.gameObject);
+
+        }
+
+        public void InitialSpawn() {
+
             //マップをスキャン
             _enemyVisibilityMap = new EnemyVisibilityMap();
             _enemyVisibilityMap.debugMode = _debugMode;
@@ -45,8 +84,11 @@ namespace Scenes.Ingame.Enemy
             _enemyVisibilityMap.GridMake(_x, _z, _range, _centerPosition);
             _enemyVisibilityMap.MapScan();
 
-            //テストとしてここでEnemy制作を依頼している
-            EnemySpawn(_enemyName, new Vector3(-10, _centerPosition.y+3, -10));            
+            //ここでEnemy制作
+            EnemySpawn(EnemyName.TestEnemy,_enemySpawnPosition);
+            //敵の沸きが完了したことを知らせる
+            IngameManager.Instance.SetReady(ReadyEnum.EnemyReady);
+
         }
 
 
@@ -54,8 +96,8 @@ namespace Scenes.Ingame.Enemy
         public void EnemySpawn(EnemyName enemeyName, Vector3 spownPosition)//位置を指定してスポーンさせたい場合
         {
             GameObject createEnemy;
-            EnemySearch createEnemySearch;
             EnemyStatus createEnemyStatus;
+            EnemyVisibilityMap createEnemyVisiviityMap = _enemyVisibilityMap.DeepCopy();
             switch (enemeyName)
             {
 
@@ -82,7 +124,9 @@ namespace Scenes.Ingame.Enemy
             if (createEnemy.TryGetComponent<EnemyStatus>(out createEnemyStatus))
             {
                 if (_debugMode) Debug.Log("作成した敵にはEnemyStatusクラスがあります");
-                createEnemyStatus.Init(_enemyVisibilityMap.DeepCopy());
+                createEnemyVisiviityMap.DontApproachPlayer();
+                createEnemyStatus.Init(createEnemyVisiviityMap);
+
             }
 
         }

--- a/Assets/Scripts/Scenes/InGame/Enemy/EnemyVisibilityMap.cs
+++ b/Assets/Scripts/Scenes/InGame/Enemy/EnemyVisibilityMap.cs
@@ -349,18 +349,22 @@ namespace Scenes.Ingame.Enemy
             if (!(enemyPosition.x < centerPosition.x + (visivilityAreaGrid.Count + 0.5) * gridRange) && (centerPosition.x - 0.5 * gridRange < enemyPosition.x))
             {
                 Debug.LogError("EnemyPosition.xが範囲外です");
+                return false;
             }
             if (!(enemyPosition.z < centerPosition.z + (visivilityAreaGrid.Count + 0.5) * gridRange) && (centerPosition.z - 0.5 * gridRange < enemyPosition.z))
             {
                 Debug.LogError("EnemyPosition.zが範囲外です");
+                return false;
             }
             if (!(playerPosition.x < centerPosition.x + (visivilityAreaGrid.Count + 0.5) * gridRange) && (centerPosition.x - 0.5 * gridRange < playerPosition.x))
             {
                 Debug.LogError("PlayerPosition.xが範囲外です");
+                return false;
             }
             if (!(playerPosition.z < centerPosition.z + (visivilityAreaGrid.Count + 0.5) * gridRange) && (centerPosition.z - 0.5 * gridRange < playerPosition.z))
             {
                 Debug.LogError("EPlayerPosition.zが範囲外です");
+                return false;
             }
             //Enemyから見れる可能性のあるマスを取得
             byte enemyGridPositionX, enemyGridPositionZ;

--- a/Assets/Scripts/Scenes/InGame/Enemy/EnemyVisibilityMap.cs
+++ b/Assets/Scripts/Scenes/InGame/Enemy/EnemyVisibilityMap.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.UIElements;
 using static UnityEditor.Progress;
 
 
@@ -514,15 +515,55 @@ namespace Scenes.Ingame.Enemy
 
 
 
+        /// <summary>
+        /// プレイヤーの周辺に最初近づかないようにするために使用
+        /// </summary>
+        public void DontApproachPlayer()
+        {
+            Vector3 playerPosition = GameObject.Find("Player").transform.position;
+            if (debugMode) Debug.Log("プレイヤーにスポーン直後接近しないように対処");
+            VisivilityArea newVisivilityArea;
+            if ((playerPosition.x < centerPosition.x + (visivilityAreaGrid.Count + 0.5) * gridRange) && (centerPosition.x - 0.5 * gridRange < playerPosition.x))
+            {//x座標がマップの範囲内であるかどうか
+                if ((playerPosition.z < centerPosition.z + (visivilityAreaGrid[0].Count + 0.5) * gridRange) && (centerPosition.z - 0.5 * gridRange < playerPosition.z)) //z座標がマップの範囲内であるかどうか
+                {
+                    for (byte x = 0; x < visivilityAreaGrid.Count(); x++)
+                    {
+                        for (byte z = 0; z < visivilityAreaGrid[0].Count(); z++)
+                        {
+                            //マスが対象範囲(ハードコードで50にしてある)か調べる                          
+                            if (50 > Vector3.Magnitude(playerPosition - (centerPosition + new Vector3(x, 0, z) * gridRange)))
+                            {
+
+                                //対象内の場合見た回数を0とする
+                                newVisivilityArea = new VisivilityArea((byte)(visivilityAreaGrid[x][z].watchNum + 1), visivilityAreaGrid[x][z].canVisivleAreaPosition);
+                                visivilityAreaGrid[x][z] = newVisivilityArea;
+                                if (debugMode) { DrawCross((centerPosition + new Vector3(x, 0, z) * gridRange), 5, Color.magenta, 2f); }
+
+                            }
+                            else
+                            {
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    if (debugMode) Debug.Log("z座標がマップからはみ出ています");
+                }
+                if (debugMode) Debug.Log("x座標がマップからはみ出ています");
 
 
+            }
 
+        }
 
         private void DrawCross(Vector3 position, float size, Color color, float time)
         {
             Debug.DrawLine(position + new Vector3(size / 2, 0, size / 2), position + new Vector3(-size, 0, -size), color, time);
             Debug.DrawLine(position + new Vector3(-size / 2, 0, size / 2), position + new Vector3(size / 2, 0, -size / 2), color, time);
         }
+
 
     }
 }


### PR DESCRIPTION
## 概要
<!--
InGameシーンでエネミーが動くようにした
-->
InGameシーンでエネミーが動くようにした。スポーン直後のPlayerに接近しないようにした

## 変更点
<!--
変更した箇所について記入してください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
- InGameシーンでEnemySpwanerの設定をすました
- EnemySpawnerがゲーム開始時に敵の作成に成功したことをInGameManagerに通知するようになった
- 生成直後のEnemyがすぐに探索先をPlayerのいる位置にしないようにした

## テスト
<!--
プッシュする前に下記のことを確認したかを確かめてください。確認した場合はチェックを付けてください。
※チェックの付け方 []を[x]とする。
-->
 - [x] 複雑であったり、わかりにくい部分のコメントアウトでの説明
 - [x] 命名規則の統一
 - [x] 変更箇所にエラーが発生してるかの確認
 - [] ビルドが成功するかの確認
 
## 問題
<!--
現状なにか問題が発生している場合はこちらに書いてください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
-視界のマッピングは二階建てとドアに対応したらやります

## 作り直す前のプルリクエストに対する返答
-RightCheckの配列の範囲外であるという内容のエラーは、その前にあるzが範囲外というDebugLogErrorの条件を満たすようにマップ作成時のxz方向の広さを調節することで解決します。おそらくこれが発生した時はプレイヤーが壁の外にいたはず。
