### PR TITLE
入れない部屋生成時のＭＡＰの修正

### DIFF
--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -13,6 +13,12 @@ using System;
 
 namespace Scenes.Ingame.Stage
 {
+    public enum generateType
+    {
+        XandY = 0,
+        X = 1,
+        Y = 2,
+    }
     /// <summary>
     /// 動作説明
     /// １._stageSizeに設定されたサイズのステージデータを生成（配列の_stageGenerateDataで管理）
@@ -549,7 +555,7 @@ namespace Scenes.Ingame.Stage
         /// <summary>
         /// x軸とy軸に１つずつ通路の作成
         /// </summary>
-        private RoomData[,] GenerateAisle(CancellationToken token, RoomData[,] stage,int setValueX = -1,, int setValueX = -1)
+        private RoomData[,] GenerateAisle(CancellationToken token, RoomData[,] stage,int setValueX = -1,int setValueY = -1, generateType type = generateType.XandY)
         {
             int xAisleNumber = GenerateXAisle(stage, (int)_stageSize.x - OFFSET, OFFSET);
             int yAisleNumber = GenerateYAisle(stage, (int)_stageSize.y - OFFSET, OFFSET);
@@ -559,7 +565,7 @@ namespace Scenes.Ingame.Stage
             if (viewDebugLog) Debug.Log($"IslePosition => x = {xAisleNumber},y = {yAisleNumber}");
             RoomData initialData = new RoomData();
             initialData.RoomDataSet(RoomType.none, 0);
-            var newStageGenerateData = new RoomData[stage.GetLength(0) + 1, stage.GetLength(1) + 1];
+            var newStageGenerateData = new RoomData[stage.GetLength(0) + (type != generateType.Y ? 1 :0), stage.GetLength(1) + (type != generateType.X ? 1 : 0)];
             for (int i = 0; i < (int)_stageSize.y + 1; i++)
             {
                 for (int j = 0; j < (int)_stageSize.x; j++)
@@ -567,30 +573,32 @@ namespace Scenes.Ingame.Stage
                     newStageGenerateData[i, j] = initialData;
                 }
             }
-            //X軸を通路分ずらす処理
-            for (int y = 0; y < stage.GetLength(1); y++)
+            if(type != generateType.Y)
             {
-                xSlide = false;
-                for (int x = 0; x < stage.GetLength(0); x++)
+                //X軸を通路分ずらす処理
+                for (int y = 0; y < stage.GetLength(1); y++)
                 {
-                    if (xSlide == false)
+                    xSlide = false;
+                    for (int x = 0; x < stage.GetLength(0); x++)
                     {
-                        if (x >= xAisleNumber && stage[x, y].RoomId != stage[x - 1, y].RoomId)
+                        if (xSlide == false)
                         {
-                            xSlide = true;
+                            if (x >= xAisleNumber && stage[x, y].RoomId != stage[x - 1, y].RoomId)
+                            {
+                                xSlide = true;
+                            }
                         }
-                    }
-                    if (xSlide)
-                    {
-                        newStageGenerateData[x + 1, y] = stage[x, y];
-                    }
-                    else
-                    {
-                        newStageGenerateData[x, y] = stage[x, y];
+                        if (xSlide)
+                        {
+                            newStageGenerateData[x + 1, y] = stage[x, y];
+                        }
+                        else
+                        {
+                            newStageGenerateData[x, y] = stage[x, y];
+                        }
                     }
                 }
             }
-            //y軸を通路分ずらす処理
             var tempXPlotData = new RoomData[newStageGenerateData.GetLength(0), newStageGenerateData.GetLength(1)];
             for (int i = 0; i < (int)_stageSize.y + 1; i++)
             {
@@ -599,22 +607,26 @@ namespace Scenes.Ingame.Stage
                     tempXPlotData[i, j] = initialData;
                 }
             }
-            for (int x = 0; x < newStageGenerateData.GetLength(0); x++)
+            if (type != generateType.X)
             {
-                ySlide = false;
-                for (int y = 0; y < newStageGenerateData.GetLength(1) - 1; y++)
+                //y軸を通路分ずらす処理
+                for (int x = 0; x < newStageGenerateData.GetLength(0); x++)
                 {
-                    if (y >= yAisleNumber && newStageGenerateData[x, y].RoomId != newStageGenerateData[x, y - 1].RoomId)
+                    ySlide = false;
+                    for (int y = 0; y < newStageGenerateData.GetLength(1) - 1; y++)
                     {
-                        ySlide = true;
-                    }
-                    if (ySlide)
-                    {
-                        tempXPlotData[x, y + 1] = newStageGenerateData[x, y];
-                    }
-                    else
-                    {
-                        tempXPlotData[x, y] = newStageGenerateData[x, y];
+                        if (y >= yAisleNumber && newStageGenerateData[x, y].RoomId != newStageGenerateData[x, y - 1].RoomId)
+                        {
+                            ySlide = true;
+                        }
+                        if (ySlide)
+                        {
+                            tempXPlotData[x, y + 1] = newStageGenerateData[x, y];
+                        }
+                        else
+                        {
+                            tempXPlotData[x, y] = newStageGenerateData[x, y];
+                        }
                     }
                 }
             }

--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -13,12 +13,6 @@ using System;
 
 namespace Scenes.Ingame.Stage
 {
-    public enum generateType
-    {
-        XandY = 0,
-        X = 1,
-        Y = 2,
-    }
     /// <summary>
     /// 動作説明
     /// １._stageSizeに設定されたサイズのステージデータを生成（配列の_stageGenerateDataで管理）
@@ -89,7 +83,7 @@ namespace Scenes.Ingame.Stage
             for (int floor = 1; floor <= 2; floor++)
             {
                 RoomData[,] targetFloor = new RoomData[(int)_stageSize.x, (int)_stageSize.y];   //データの初期化
-                RoomPlotId(RoomType.room2x2Stair, new Vector2(0, 0), targetFloor);              //確定の階段部屋データの入力
+                RoomPlotId(RoomType.room2x2Stair, new Vector2((int)_stageSize.x - 2, (int)_stageSize.y - 2), targetFloor);//確定の階段部屋データの入力
                 RandomFullSpaceRoomPlot(targetFloor, LARGEROOM, MEDIUMROOM, SMALLROOM);                                //データに部屋のIDの割り当て
                 if (viewDebugLog) DebugStageData(targetFloor);
                 await RommShaping(token, targetFloor);                                          //空間を埋めるように部屋の大きさを調整
@@ -555,7 +549,7 @@ namespace Scenes.Ingame.Stage
         /// <summary>
         /// x軸とy軸に１つずつ通路の作成
         /// </summary>
-        private RoomData[,] GenerateAisle(CancellationToken token, RoomData[,] stage,int setValueX = -1,int setValueY = -1, generateType type = generateType.XandY)
+        private RoomData[,] GenerateAisle(CancellationToken token, RoomData[,] stage)
         {
             int xAisleNumber = GenerateXAisle(stage, (int)_stageSize.x - OFFSET, OFFSET);
             int yAisleNumber = GenerateYAisle(stage, (int)_stageSize.y - OFFSET, OFFSET);
@@ -565,7 +559,7 @@ namespace Scenes.Ingame.Stage
             if (viewDebugLog) Debug.Log($"IslePosition => x = {xAisleNumber},y = {yAisleNumber}");
             RoomData initialData = new RoomData();
             initialData.RoomDataSet(RoomType.none, 0);
-            var newStageGenerateData = new RoomData[stage.GetLength(0) + (type != generateType.Y ? 1 :0), stage.GetLength(1) + (type != generateType.X ? 1 : 0)];
+            var newStageGenerateData = new RoomData[stage.GetLength(0) + 1, stage.GetLength(1) + 1];
             for (int i = 0; i < (int)_stageSize.y + 1; i++)
             {
                 for (int j = 0; j < (int)_stageSize.x; j++)
@@ -573,8 +567,6 @@ namespace Scenes.Ingame.Stage
                     newStageGenerateData[i, j] = initialData;
                 }
             }
-            if(type != generateType.Y)
-            {
                 //X軸を通路分ずらす処理
                 for (int y = 0; y < stage.GetLength(1); y++)
                 {
@@ -598,7 +590,6 @@ namespace Scenes.Ingame.Stage
                         }
                     }
                 }
-            }
             var tempXPlotData = new RoomData[newStageGenerateData.GetLength(0), newStageGenerateData.GetLength(1)];
             for (int i = 0; i < (int)_stageSize.y + 1; i++)
             {
@@ -607,8 +598,6 @@ namespace Scenes.Ingame.Stage
                     tempXPlotData[i, j] = initialData;
                 }
             }
-            if (type != generateType.X)
-            {
                 //y軸を通路分ずらす処理
                 for (int x = 0; x < newStageGenerateData.GetLength(0); x++)
                 {
@@ -629,7 +618,6 @@ namespace Scenes.Ingame.Stage
                         }
                     }
                 }
-            }
             return tempXPlotData;
         }
         /// <summary>
@@ -950,7 +938,7 @@ namespace Scenes.Ingame.Stage
             }
             foreach (GameObject target in instantiateRooms)
             {
-                if (spawnPositionRoom == target) continue;
+                if (spawnPositionRoom == target || target == null) continue;
 
                 if (!IsConnected(agent, target.transform.position))
                 {


### PR DESCRIPTION
## 概要
<!--
追加した機能について記入してください。
-->
入れない部屋生成時にドアの位置を再生成
※現状プレファブの種類数の都合でＭＡＰ左下の部分がどうしても入れないようになることが多いです
※作業の仮置きです
## 変更点
<!--
変更した箇所について記入してください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->

## テスト
 <!-- 
 動作テストを行うシーン名を下記のように書いてください。
  動作確認用シーン：Ingame_Player
 -->
 動作確認用シーン：
<!--
プッシュする前に下記のことを確認したかを確かめてください。確認した場合はチェックを付けてください。
※チェックの付け方 []を[x]とする。
-->
 - [] 複雑であったり、わかりにくい部分のコメントアウトでの説明
 - [] 命名規則の統一
 - [x] 変更箇所にエラーが発生してるかの確認
 - [] ビルドが成功するかの確認
## 問題
<!--
現状なにか問題が発生している場合はこちらに書いてください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
