### PR TITLE
ステージ生成の軽量化

### DIFF
--- a/Assets/Resources/Materials/Marker.meta
+++ b/Assets/Resources/Materials/Marker.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbe04e899e8f54127868008343e2ad2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Materials/Marker/MarkerGreen.mat
+++ b/Assets/Resources/Materials/Marker/MarkerGreen.mat
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MarkerGreen
+  m_Shader: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _DISABLE_SSR_TRANSPARENT
+  - _NORMALMAP_TANGENT_SPACE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2225
+  stringTagMap: {}
+  disabledShaderPasses:
+  - TransparentDepthPrepass
+  - TransparentDepthPostpass
+  - TransparentBackface
+  - RayTracingPrepass
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AnisotropyMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CoatMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissiveColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _HeightMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmissionMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmittanceColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AORemapMax: 1
+    - _AORemapMin: 0
+    - _ATDistance: 1
+    - _AddPrecomputedVelocity: 0
+    - _AlbedoAffectEmissive: 0
+    - _AlphaCutoff: 0.5
+    - _AlphaCutoffEnable: 0
+    - _AlphaCutoffPostpass: 0.5
+    - _AlphaCutoffPrepass: 0.5
+    - _AlphaCutoffShadow: 0.5
+    - _AlphaDstBlend: 0
+    - _AlphaRemapMax: 1
+    - _AlphaRemapMin: 0
+    - _AlphaSrcBlend: 1
+    - _Anisotropy: 0
+    - _BlendMode: 0
+    - _CoatMask: 0
+    - _CullMode: 2
+    - _CullModeForward: 2
+    - _Cutoff: 0.5
+    - _DepthOffsetEnable: 0
+    - _DetailAlbedoScale: 1
+    - _DetailNormalScale: 1
+    - _DetailSmoothnessScale: 1
+    - _DiffusionProfile: 0
+    - _DiffusionProfileHash: 0
+    - _DisplacementLockObjectScale: 1
+    - _DisplacementLockTilingScale: 1
+    - _DisplacementMode: 0
+    - _DoubleSidedEnable: 0
+    - _DoubleSidedGIMode: 0
+    - _DoubleSidedNormalMode: 1
+    - _DstBlend: 0
+    - _EmissiveColorMode: 1
+    - _EmissiveExposureWeight: 1
+    - _EmissiveIntensity: 1
+    - _EmissiveIntensityUnit: 0
+    - _EnableBlendModePreserveSpecularLighting: 1
+    - _EnableFogOnTransparent: 1
+    - _EnableGeometricSpecularAA: 0
+    - _EnergyConservingSpecularColor: 1
+    - _HeightAmplitude: 0.02
+    - _HeightCenter: 0.5
+    - _HeightMapParametrization: 0
+    - _HeightMax: 1
+    - _HeightMin: -1
+    - _HeightOffset: 0
+    - _HeightPoMAmplitude: 2
+    - _HeightTessAmplitude: 2
+    - _HeightTessCenter: 0.5
+    - _InvTilingScale: 1
+    - _Ior: 1.5
+    - _IridescenceMask: 1
+    - _IridescenceThickness: 1
+    - _LinkDetailsWithBase: 1
+    - _MaterialID: 1
+    - _Metallic: 0
+    - _MetallicRemapMax: 1
+    - _MetallicRemapMin: 0
+    - _NormalMapSpace: 0
+    - _NormalScale: 1
+    - _ObjectSpaceUVMapping: 0
+    - _ObjectSpaceUVMappingEmissive: 0
+    - _OpaqueCullMode: 2
+    - _PPDLodThreshold: 5
+    - _PPDMaxSamples: 15
+    - _PPDMinSamples: 5
+    - _PPDPrimitiveLength: 1
+    - _PPDPrimitiveWidth: 1
+    - _RayTracing: 0
+    - _ReceivesSSR: 1
+    - _ReceivesSSRTransparent: 0
+    - _RefractionModel: 0
+    - _Smoothness: 0.5
+    - _SmoothnessRemapMax: 1
+    - _SmoothnessRemapMin: 0
+    - _SpecularAAScreenSpaceVariance: 0.1
+    - _SpecularAAThreshold: 0.2
+    - _SpecularOcclusionMode: 1
+    - _SrcBlend: 1
+    - _StencilRef: 0
+    - _StencilRefDepth: 8
+    - _StencilRefGBuffer: 10
+    - _StencilRefMV: 40
+    - _StencilWriteMask: 6
+    - _StencilWriteMaskDepth: 9
+    - _StencilWriteMaskGBuffer: 15
+    - _StencilWriteMaskMV: 41
+    - _SubsurfaceMask: 1
+    - _SupportDecals: 1
+    - _SurfaceType: 0
+    - _TexWorldScale: 1
+    - _TexWorldScaleEmissive: 1
+    - _Thickness: 1
+    - _TransmissionEnable: 1
+    - _TransmissionMask: 1
+    - _TransparentBackfaceEnable: 0
+    - _TransparentCullMode: 2
+    - _TransparentDepthPostpassEnable: 0
+    - _TransparentDepthPrepassEnable: 0
+    - _TransparentSortPriority: 0
+    - _TransparentWritingMotionVec: 0
+    - _TransparentZWrite: 0
+    - _UVBase: 0
+    - _UVDetail: 0
+    - _UVEmissive: 0
+    - _UseEmissiveIntensity: 0
+    - _UseShadowThreshold: 0
+    - _ZTestDepthEqualForOpaque: 3
+    - _ZTestGBuffer: 4
+    - _ZTestTransparent: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0.92262375, b: 0.2216981, a: 1}
+    - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}
+    - _Color: {r: 1, g: 0.92262375, b: 0.22169808, a: 1}
+    - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
+    - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
+    - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissiveColor: {r: 0.1934723, g: 2, b: 0.08376967, a: 1}
+    - _EmissiveColorLDR: {r: 0, g: 0, b: 0, a: 1}
+    - _InvPrimScale: {r: 1, g: 1, b: 0, a: 0}
+    - _IridescenceThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
+    - _ThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _TransmittanceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _UVDetailsMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &3904427391613860115
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da692e001514ec24dbc4cca1949ff7e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 13
+  hdPluginSubTargetMaterialVersions:
+    m_Keys: []
+    m_Values: 

--- a/Assets/Resources/Materials/Marker/MarkerGreen.mat.meta
+++ b/Assets/Resources/Materials/Marker/MarkerGreen.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d9bde063e596417bab6b1461c1e27cd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Materials/Marker/MarkerRed.mat
+++ b/Assets/Resources/Materials/Marker/MarkerRed.mat
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MarkerRed
+  m_Shader: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _DISABLE_SSR_TRANSPARENT
+  - _NORMALMAP_TANGENT_SPACE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2225
+  stringTagMap: {}
+  disabledShaderPasses:
+  - TransparentDepthPrepass
+  - TransparentDepthPostpass
+  - TransparentBackface
+  - RayTracingPrepass
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AnisotropyMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CoatMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissiveColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _HeightMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmissionMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmittanceColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AORemapMax: 1
+    - _AORemapMin: 0
+    - _ATDistance: 1
+    - _AddPrecomputedVelocity: 0
+    - _AlbedoAffectEmissive: 0
+    - _AlphaCutoff: 0.5
+    - _AlphaCutoffEnable: 0
+    - _AlphaCutoffPostpass: 0.5
+    - _AlphaCutoffPrepass: 0.5
+    - _AlphaCutoffShadow: 0.5
+    - _AlphaDstBlend: 0
+    - _AlphaRemapMax: 1
+    - _AlphaRemapMin: 0
+    - _AlphaSrcBlend: 1
+    - _Anisotropy: 0
+    - _BlendMode: 0
+    - _CoatMask: 0
+    - _CullMode: 2
+    - _CullModeForward: 2
+    - _Cutoff: 0.5
+    - _DepthOffsetEnable: 0
+    - _DetailAlbedoScale: 1
+    - _DetailNormalScale: 1
+    - _DetailSmoothnessScale: 1
+    - _DiffusionProfile: 0
+    - _DiffusionProfileHash: 0
+    - _DisplacementLockObjectScale: 1
+    - _DisplacementLockTilingScale: 1
+    - _DisplacementMode: 0
+    - _DoubleSidedEnable: 0
+    - _DoubleSidedGIMode: 0
+    - _DoubleSidedNormalMode: 1
+    - _DstBlend: 0
+    - _EmissiveColorMode: 1
+    - _EmissiveExposureWeight: 1
+    - _EmissiveIntensity: 1
+    - _EmissiveIntensityUnit: 0
+    - _EnableBlendModePreserveSpecularLighting: 1
+    - _EnableFogOnTransparent: 1
+    - _EnableGeometricSpecularAA: 0
+    - _EnergyConservingSpecularColor: 1
+    - _HeightAmplitude: 0.02
+    - _HeightCenter: 0.5
+    - _HeightMapParametrization: 0
+    - _HeightMax: 1
+    - _HeightMin: -1
+    - _HeightOffset: 0
+    - _HeightPoMAmplitude: 2
+    - _HeightTessAmplitude: 2
+    - _HeightTessCenter: 0.5
+    - _InvTilingScale: 1
+    - _Ior: 1.5
+    - _IridescenceMask: 1
+    - _IridescenceThickness: 1
+    - _LinkDetailsWithBase: 1
+    - _MaterialID: 1
+    - _Metallic: 0
+    - _MetallicRemapMax: 1
+    - _MetallicRemapMin: 0
+    - _NormalMapSpace: 0
+    - _NormalScale: 1
+    - _ObjectSpaceUVMapping: 0
+    - _ObjectSpaceUVMappingEmissive: 0
+    - _OpaqueCullMode: 2
+    - _PPDLodThreshold: 5
+    - _PPDMaxSamples: 15
+    - _PPDMinSamples: 5
+    - _PPDPrimitiveLength: 1
+    - _PPDPrimitiveWidth: 1
+    - _RayTracing: 0
+    - _ReceivesSSR: 1
+    - _ReceivesSSRTransparent: 0
+    - _RefractionModel: 0
+    - _Smoothness: 0.5
+    - _SmoothnessRemapMax: 1
+    - _SmoothnessRemapMin: 0
+    - _SpecularAAScreenSpaceVariance: 0.1
+    - _SpecularAAThreshold: 0.2
+    - _SpecularOcclusionMode: 1
+    - _SrcBlend: 1
+    - _StencilRef: 0
+    - _StencilRefDepth: 8
+    - _StencilRefGBuffer: 10
+    - _StencilRefMV: 40
+    - _StencilWriteMask: 6
+    - _StencilWriteMaskDepth: 9
+    - _StencilWriteMaskGBuffer: 15
+    - _StencilWriteMaskMV: 41
+    - _SubsurfaceMask: 1
+    - _SupportDecals: 1
+    - _SurfaceType: 0
+    - _TexWorldScale: 1
+    - _TexWorldScaleEmissive: 1
+    - _Thickness: 1
+    - _TransmissionEnable: 1
+    - _TransmissionMask: 1
+    - _TransparentBackfaceEnable: 0
+    - _TransparentCullMode: 2
+    - _TransparentDepthPostpassEnable: 0
+    - _TransparentDepthPrepassEnable: 0
+    - _TransparentSortPriority: 0
+    - _TransparentWritingMotionVec: 0
+    - _TransparentZWrite: 0
+    - _UVBase: 0
+    - _UVDetail: 0
+    - _UVEmissive: 0
+    - _UseEmissiveIntensity: 0
+    - _UseShadowThreshold: 0
+    - _ZTestDepthEqualForOpaque: 3
+    - _ZTestGBuffer: 4
+    - _ZTestTransparent: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0.2235294, b: 0.32927465, a: 1}
+    - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}
+    - _Color: {r: 1, g: 0.22352937, b: 0.32927462, a: 1}
+    - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
+    - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
+    - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissiveColor: {r: 2, g: 0.08376967, b: 0.08376967, a: 1}
+    - _EmissiveColorLDR: {r: 0, g: 0, b: 0, a: 1}
+    - _InvPrimScale: {r: 1, g: 1, b: 0, a: 0}
+    - _IridescenceThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
+    - _ThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _TransmittanceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _UVDetailsMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &3904427391613860115
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da692e001514ec24dbc4cca1949ff7e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 13
+  hdPluginSubTargetMaterialVersions:
+    m_Keys: []
+    m_Values: 

--- a/Assets/Resources/Materials/Marker/MarkerRed.mat.meta
+++ b/Assets/Resources/Materials/Marker/MarkerRed.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8255381bb45ff4ceeb84ebbe460267a9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Materials/Marker/MarkerYellow.mat
+++ b/Assets/Resources/Materials/Marker/MarkerYellow.mat
@@ -1,0 +1,276 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MarkerYellow
+  m_Shader: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords:
+  - _DISABLE_SSR_TRANSPARENT
+  - _NORMALMAP_TANGENT_SPACE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2225
+  stringTagMap: {}
+  disabledShaderPasses:
+  - TransparentDepthPrepass
+  - TransparentDepthPostpass
+  - TransparentBackface
+  - RayTracingPrepass
+  - MOTIONVECTORS
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AnisotropyMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BaseColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BentNormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _CoatMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissiveColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _HeightMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescenceThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecularColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SubsurfaceMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TangentMapOS:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ThicknessMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmissionMaskMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _TransmittanceColorMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AORemapMax: 1
+    - _AORemapMin: 0
+    - _ATDistance: 1
+    - _AddPrecomputedVelocity: 0
+    - _AlbedoAffectEmissive: 0
+    - _AlphaCutoff: 0.5
+    - _AlphaCutoffEnable: 0
+    - _AlphaCutoffPostpass: 0.5
+    - _AlphaCutoffPrepass: 0.5
+    - _AlphaCutoffShadow: 0.5
+    - _AlphaDstBlend: 0
+    - _AlphaRemapMax: 1
+    - _AlphaRemapMin: 0
+    - _AlphaSrcBlend: 1
+    - _Anisotropy: 0
+    - _BlendMode: 0
+    - _CoatMask: 0
+    - _CullMode: 2
+    - _CullModeForward: 2
+    - _Cutoff: 0.5
+    - _DepthOffsetEnable: 0
+    - _DetailAlbedoScale: 1
+    - _DetailNormalScale: 1
+    - _DetailSmoothnessScale: 1
+    - _DiffusionProfile: 0
+    - _DiffusionProfileHash: 0
+    - _DisplacementLockObjectScale: 1
+    - _DisplacementLockTilingScale: 1
+    - _DisplacementMode: 0
+    - _DoubleSidedEnable: 0
+    - _DoubleSidedGIMode: 0
+    - _DoubleSidedNormalMode: 1
+    - _DstBlend: 0
+    - _EmissiveColorMode: 1
+    - _EmissiveExposureWeight: 1
+    - _EmissiveIntensity: 1
+    - _EmissiveIntensityUnit: 0
+    - _EnableBlendModePreserveSpecularLighting: 1
+    - _EnableFogOnTransparent: 1
+    - _EnableGeometricSpecularAA: 0
+    - _EnergyConservingSpecularColor: 1
+    - _HeightAmplitude: 0.02
+    - _HeightCenter: 0.5
+    - _HeightMapParametrization: 0
+    - _HeightMax: 1
+    - _HeightMin: -1
+    - _HeightOffset: 0
+    - _HeightPoMAmplitude: 2
+    - _HeightTessAmplitude: 2
+    - _HeightTessCenter: 0.5
+    - _InvTilingScale: 1
+    - _Ior: 1.5
+    - _IridescenceMask: 1
+    - _IridescenceThickness: 1
+    - _LinkDetailsWithBase: 1
+    - _MaterialID: 1
+    - _Metallic: 0
+    - _MetallicRemapMax: 1
+    - _MetallicRemapMin: 0
+    - _NormalMapSpace: 0
+    - _NormalScale: 1
+    - _ObjectSpaceUVMapping: 0
+    - _ObjectSpaceUVMappingEmissive: 0
+    - _OpaqueCullMode: 2
+    - _PPDLodThreshold: 5
+    - _PPDMaxSamples: 15
+    - _PPDMinSamples: 5
+    - _PPDPrimitiveLength: 1
+    - _PPDPrimitiveWidth: 1
+    - _RayTracing: 0
+    - _ReceivesSSR: 1
+    - _ReceivesSSRTransparent: 0
+    - _RefractionModel: 0
+    - _Smoothness: 0.5
+    - _SmoothnessRemapMax: 1
+    - _SmoothnessRemapMin: 0
+    - _SpecularAAScreenSpaceVariance: 0.1
+    - _SpecularAAThreshold: 0.2
+    - _SpecularOcclusionMode: 1
+    - _SrcBlend: 1
+    - _StencilRef: 0
+    - _StencilRefDepth: 8
+    - _StencilRefGBuffer: 10
+    - _StencilRefMV: 40
+    - _StencilWriteMask: 6
+    - _StencilWriteMaskDepth: 9
+    - _StencilWriteMaskGBuffer: 15
+    - _StencilWriteMaskMV: 41
+    - _SubsurfaceMask: 1
+    - _SupportDecals: 1
+    - _SurfaceType: 0
+    - _TexWorldScale: 1
+    - _TexWorldScaleEmissive: 1
+    - _Thickness: 1
+    - _TransmissionEnable: 1
+    - _TransmissionMask: 1
+    - _TransparentBackfaceEnable: 0
+    - _TransparentCullMode: 2
+    - _TransparentDepthPostpassEnable: 0
+    - _TransparentDepthPrepassEnable: 0
+    - _TransparentSortPriority: 0
+    - _TransparentWritingMotionVec: 0
+    - _TransparentZWrite: 0
+    - _UVBase: 0
+    - _UVDetail: 0
+    - _UVEmissive: 0
+    - _UseEmissiveIntensity: 0
+    - _UseShadowThreshold: 0
+    - _ZTestDepthEqualForOpaque: 3
+    - _ZTestGBuffer: 4
+    - _ZTestTransparent: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 0.92262375, b: 0.2216981, a: 1}
+    - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}
+    - _Color: {r: 1, g: 0.92262375, b: 0.22169808, a: 1}
+    - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
+    - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
+    - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissiveColor: {r: 2, g: 1.6615402, b: 0.08183042, a: 1}
+    - _EmissiveColorLDR: {r: 0, g: 0, b: 0, a: 1}
+    - _InvPrimScale: {r: 1, g: 1, b: 0, a: 0}
+    - _IridescenceThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
+    - _ThicknessRemap: {r: 0, g: 1, b: 0, a: 0}
+    - _TransmittanceColor: {r: 1, g: 1, b: 1, a: 1}
+    - _UVDetailsMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMask: {r: 1, g: 0, b: 0, a: 0}
+    - _UVMappingMaskEmissive: {r: 1, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []
+--- !u!114 &3904427391613860115
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da692e001514ec24dbc4cca1949ff7e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 13
+  hdPluginSubTargetMaterialVersions:
+    m_Keys: []
+    m_Values: 

--- a/Assets/Resources/Materials/Marker/MarkerYellow.mat.meta
+++ b/Assets/Resources/Materials/Marker/MarkerYellow.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f900fbcba81e423ea1cc0fe7e87bd63
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefab/Stage.prefab
+++ b/Assets/Resources/Prefab/Stage.prefab
@@ -330,6 +330,7 @@ GameObject:
   - component: {fileID: 7712768426329541612}
   - component: {fileID: 2817882825628233842}
   - component: {fileID: 3700284104005568679}
+  - component: {fileID: 2263348169807701979}
   m_Layer: 0
   m_Name: Stage
   m_TagString: Untagged
@@ -374,8 +375,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _stageSize: {x: 12, y: 12}
+  viewDebugLog: 0
   line: {fileID: 3625524245052678187}
-  LARGEROOM: 9
+  marker: {fileID: 0}
+  markerRed: {fileID: 0}
+  LARGEROOM: 8
   MEDIUMROOM: 5
   SMALLROOM: 4
   floorObject: {fileID: 1938581473151959162}
@@ -430,6 +434,18 @@ MonoBehaviour:
   _2x4CorridorPrefab: {fileID: 7104717311803946632, guid: f38c06f79a308e740b622eea7ba9fd9e, type: 3}
   _4x2CorridorPrefab: {fileID: 7104717311803946632, guid: eea40fcafa20b384e929f8454bcf05ae, type: 3}
   _2x2CorridorPrefab: {fileID: 8786186942910803785, guid: 248bd6a9ba5451f41a5e22e3995f2c3d, type: 3}
+--- !u!114 &2263348169807701979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6624500817061936141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b04419c4c8a04cac9286f56e740d94f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7456130407012831217
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/InGame_Stage.unity
+++ b/Assets/Scenes/InGame_Stage.unity
@@ -1078,10 +1078,6 @@ PrefabInstance:
       propertyPath: markerRed
       value: 
       objectReference: {fileID: 586647452}
-    - target: {fileID: 2817882825628233842, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
-      propertyPath: viewDebugLog
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 4382990553633188936, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1145,28 +1141,8 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 6624500817061936141, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1780856373}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
---- !u!1 &1780856369 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6624500817061936141, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
-  m_PrefabInstance: {fileID: 1780856368}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1780856373
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1780856369}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b04419c4c8a04cac9286f56e740d94f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1887355919
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/InGame_Stage.unity
+++ b/Assets/Scenes/InGame_Stage.unity
@@ -430,6 +430,111 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: c08255eb08d546a44891d2ef778a1e53, type: 3}
+--- !u!1 &586647452
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 586647456}
+  - component: {fileID: 586647455}
+  - component: {fileID: 586647454}
+  - component: {fileID: 586647453}
+  m_Layer: 0
+  m_Name: MarkerRed
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &586647453
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586647452}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &586647454
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586647452}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8255381bb45ff4ceeb84ebbe460267a9, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &586647455
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586647452}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &586647456
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586647452}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &593448760
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -965,6 +1070,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 2817882825628233842, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      propertyPath: marker
+      value: 
+      objectReference: {fileID: 2070789274}
+    - target: {fileID: 2817882825628233842, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      propertyPath: markerRed
+      value: 
+      objectReference: {fileID: 586647452}
+    - target: {fileID: 2817882825628233842, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      propertyPath: viewDebugLog
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4382990553633188936, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1162,4 +1279,109 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2070789274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2070789278}
+  - component: {fileID: 2070789277}
+  - component: {fileID: 2070789276}
+  - component: {fileID: 2070789275}
+  m_Layer: 0
+  m_Name: Marker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &2070789275
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070789274}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2070789276
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070789274}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 8f900fbcba81e423ea1cc0fe7e87bd63, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2070789277
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070789274}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2070789278
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070789274}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/InGame_Stage.unity
+++ b/Assets/Scenes/InGame_Stage.unity
@@ -1080,7 +1080,7 @@ PrefabInstance:
       objectReference: {fileID: 586647452}
     - target: {fileID: 2817882825628233842, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: viewDebugLog
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4382990553633188936, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: m_IsActive

--- a/Assets/Scenes/InGame_Stage.unity
+++ b/Assets/Scenes/InGame_Stage.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.026192013, g: 0.028766159, b: 0.03289378, a: 1}
+  m_IndirectSpecularColor: {r: 0.00022222291, g: 0.00024406522, b: 0.00027909366, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -965,6 +965,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4382990553633188936, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6624500817061936141, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
       propertyPath: m_Name
       value: Stage
@@ -1013,11 +1017,39 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7984266189662050798, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8953441585888980059, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6624500817061936141, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1780856373}
   m_SourcePrefab: {fileID: 100100000, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+--- !u!1 &1780856369 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6624500817061936141, guid: 3062acad21caa694c9b66f8f6d543cb5, type: 3}
+  m_PrefabInstance: {fileID: 1780856368}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1780856373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1780856369}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b04419c4c8a04cac9286f56e740d94f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1887355919
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+namespace Scenes.Ingame.Stage
+{
+    public struct LinqRoomData
+    {
+        private List<string> _linqData;//隣接してる部屋を格納する
+        public List<string> linqData { get => _linqData; }
+        private bool _linqed;//SpawnRoomと隣接している場合はtrue
+        public bool linqed { get => _linqed; }
+
+        /// <summary>
+        /// LinqDataの入力
+        /// </summary>
+        public void SetLinqRoomData(string room)
+        {
+            if(_linqData == null)
+            {
+                _linqData = new List<string>();
+            }
+            _linqData.Add(room);
+        }
+
+        /// <summary>
+        /// SpawnRoomと隣接している場合はtrue
+        /// </summary>
+        public void SetLinqed(bool value)
+        {
+            _linqed = value;
+        }
+
+        /// <summary>
+        /// SpawnRoomと隣接している場合はtrue
+        /// </summary>
+        public void ResetList()
+        {
+            if(_linqData != null && _linqData.Count > 0)
+            {
+                _linqData.Clear();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+using UnityEngine;
+
 namespace Scenes.Ingame.Stage
 {
-    public struct LinqRoomData
+    public class LinqRoomData
     {
-        private List<string> _linqData;//隣接してる部屋を格納する
+        private List<string> _linqData = new List<string>();//隣接してる部屋を格納する
         public List<string> linqData { get => _linqData; }
         private bool _linqed;//SpawnRoomと隣接している場合はtrue
         public bool linqed { get => _linqed; }
@@ -13,10 +15,6 @@ namespace Scenes.Ingame.Stage
         /// </summary>
         public void SetLinqRoomData(string room)
         {
-            if(_linqData == null)
-            {
-                _linqData = new List<string>();
-            }
             _linqData.Add(room);
         }
 

--- a/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs
@@ -5,16 +5,17 @@ namespace Scenes.Ingame.Stage
 {
     public class LinqRoomData
     {
-        private List<string> _linqData = new List<string>();//隣接してる部屋を格納する
-        public List<string> linqData { get => _linqData; }
+        private List<int> _linqData = new List<int>();//隣接してる部屋を格納する
+        public List<int> linqData { get => _linqData; }
         private bool _linqed;//SpawnRoomと隣接している場合はtrue
         public bool linqed { get => _linqed; }
 
         /// <summary>
         /// LinqDataの入力
         /// </summary>
-        public void SetLinqRoomData(string room)
+        public void SetLinqRoomData(int room)
         {
+            if (_linqData.Contains(room)) return;
             _linqData.Add(room);
         }
 

--- a/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs.meta
+++ b/Assets/Scripts/Scenes/InGame/Stage/LinqRoomData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d161acf914a4c467bb85dfe16c27da9d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scenes/InGame/Stage/RoomData.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/RoomData.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace Scenes.Ingame.Stage
 {
     public struct RoomData
@@ -5,15 +7,21 @@ namespace Scenes.Ingame.Stage
         private RoomType _roomType;
         private int _roomId;
         private string _roomName;
+        private GameObject _gameObject;
 
         public RoomType RoomType { get => _roomType; }
         public int RoomId { get => _roomId; }
         public string roomName { get => _roomName; }
+        public GameObject gameObject { get => _gameObject; }
 
         public void RoomDataSet(RoomType roomType,int roomId)
         {
             _roomType = roomType;
             _roomId = roomId;
+        }
+        public void SetGameObject(GameObject gameObject)
+        {
+            _gameObject = gameObject;
         }
         public void SetRoomName(string name)
         {

--- a/Assets/Scripts/Scenes/InGame/Stage/RoomData.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/RoomData.cs
@@ -2,16 +2,22 @@ namespace Scenes.Ingame.Stage
 {
     public struct RoomData
     {
-       private RoomType _roomType;
-       private int _roomId;
+        private RoomType _roomType;
+        private int _roomId;
+        private string _roomName;
 
         public RoomType RoomType { get => _roomType; }
         public int RoomId { get => _roomId; }
+        public string roomName { get => _roomName; }
 
         public void RoomDataSet(RoomType roomType,int roomId)
         {
             _roomType = roomType;
             _roomId = roomId;
+        }
+        public void SetRoomName(string name)
+        {
+            _roomName = name;
         }
     }
 }

--- a/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs
@@ -7,7 +7,6 @@ namespace Scenes.Ingame.Stage
     {
         public List<Vector2> GetLinqPath(string roomName)
         {
-            Debug.Log($"search data {roomName}");
             List<Vector2> linqPosition = new List<Vector2>();
             switch (roomName)
             {
@@ -62,7 +61,6 @@ namespace Scenes.Ingame.Stage
                     linqPosition.Add(SetPositionInts(1, 4));
                     break;
                 default:
-                    Debug.LogError($"Not set data {roomName}");
                     break;
             }
             return linqPosition;

--- a/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs
@@ -1,0 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+namespace Scenes.Ingame.Stage
+{
+    public class RoomLinqConfig : MonoBehaviour
+    {
+        public List<Vector2> GetLinqPath(string roomName)
+        {
+            Debug.Log($"search data {roomName}");
+            List<Vector2> linqPosition = new List<Vector2>();
+            switch (roomName)
+            {
+                case "SpawnRoom_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    break;
+                case "EscapeRoom_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    linqPosition.Add(SetPositionInts(2, 1));
+                    break;
+                case "2x2Room1_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    break;
+                case "2x2Room2_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    break;
+                case "2x2Room_Stair1f_TEMP(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    break;
+                case "2x2Room_Stair2f_TEMP(Clone)":
+                    linqPosition.Add(SetPositionInts(2, 0));
+                    break;
+                case "2x3Room1_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(1, 3));
+                    break;
+                case "2x3Room2_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(1, 3));
+                    break;
+                case "3x2Room1_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    break;
+                case "3x2Room2_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(0, 2));
+                    break;
+                case "3x3Room_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(3, 0));
+                    break;
+                case "3x3StairBottom_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(3, 0));
+                    break;
+                case "3x3StairTop_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(3, 0));
+                    break;
+                case "3x4Room_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(3, 1));
+                    break;
+                case "4x3Room_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(4, 0));
+                    break;
+                case "4x4Room_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(4, 2));
+                    linqPosition.Add(SetPositionInts(1, 4));
+                    break;
+                default:
+                    Debug.LogError($"Not set data {roomName}");
+                    break;
+            }
+            return linqPosition;
+
+        }
+        private Vector2 SetPositionInts(int x,int y)
+        {
+            Vector2 position = Vector2.zero;
+            position.x = x;
+            position.y = y;
+            return position;
+        }
+
+    }
+}

--- a/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs
@@ -50,13 +50,23 @@ namespace Scenes.Ingame.Stage
                 case "3x3StairTop_HH(Clone)":
                     linqPosition.Add(SetPositionInts(3, 0));
                     break;
-                case "3x4Room_HH(Clone)":
+                case "3x4Room1_HH(Clone)":
                     linqPosition.Add(SetPositionInts(3, 1));
                     break;
-                case "4x3Room_HH(Clone)":
+                case "3x4Room2_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(3, 1));
+                    break;
+                case "4x3Room1_HH(Clone)":
                     linqPosition.Add(SetPositionInts(4, 0));
                     break;
-                case "4x4Room_HH(Clone)":
+                case "4x3Room2_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(4, 0));
+                    break;
+                case "4x4Room1_HH(Clone)":
+                    linqPosition.Add(SetPositionInts(4, 2));
+                    linqPosition.Add(SetPositionInts(1, 4));
+                    break;
+                case "4x4Room2_HH(Clone)":
                     linqPosition.Add(SetPositionInts(4, 2));
                     linqPosition.Add(SetPositionInts(1, 4));
                     break;

--- a/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs.meta
+++ b/Assets/Scripts/Scenes/InGame/Stage/RoomLinqConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b04419c4c8a04cac9286f56e740d94f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -82,7 +82,6 @@ namespace Scenes.Ingame.Stage
             _roomLinqConfig = GetComponent<RoomLinqConfig>();
             _firsrFloorData = new RoomData[(int)_stageSize.x, (int)_stageSize.y];
             _secondFloorData = new RoomData[(int)_stageSize.x, (int)_stageSize.y];
-            if (viewDebugLog) Debug.Log($"StageSize => x = {_firsrFloorData.GetLength(0)},y = {_firsrFloorData.GetLength(1)}, total = {_firsrFloorData.Length}");
             floorNavMeshSurface = floorObject.GetComponent<NavMeshSurface>();
             IngameManager.Instance.OnInitial
                 .Subscribe(_ =>
@@ -95,7 +94,6 @@ namespace Scenes.Ingame.Stage
 
         private async UniTaskVoid Generate(CancellationToken token)
         {
-            if (viewDebugLog) Debug.Log("Stage.Generate");
             //ステージデータの計算
             for (int floor = 1; floor <= 2; floor++)
             {
@@ -238,7 +236,7 @@ namespace Scenes.Ingame.Stage
                         switch (stage[x, y].RoomType)
                         {
                             case RoomType.room2x2:
-                                if (!playerSpawnRoom && x >= 3 && y >= 3)
+                                if (!playerSpawnRoom)
                                 {
                                     instantiateRoom = Instantiate(_prefabPool.getPlayerSpawnRoomPrefab, instantiatePosition, Quaternion.identity, roomObject.transform);
                                     spawnPositionRoom = instantiateRoom;
@@ -246,7 +244,7 @@ namespace Scenes.Ingame.Stage
                                     _spawnPosition = instantiatePosition;
                                     playerSpawnRoom = true;
                                 }
-                                else if (!escapeSpawnRoom && x >= 3 && y >= 3)
+                                else if (!escapeSpawnRoom)
                                 {
                                     instantiateRoom = Instantiate(_prefabPool.getEscapeSpawnRoomPrefab, instantiatePosition, Quaternion.identity, roomObject.transform);
                                     escapeSpawnRoom = true;
@@ -254,11 +252,6 @@ namespace Scenes.Ingame.Stage
                                 else
                                 {
                                     instantiateRoom = Instantiate(_prefabPool.get2x2RoomPrefab[UnityEngine.Random.Range(0, _prefabPool.get2x2RoomPrefab.Length)], instantiatePosition, Quaternion.identity, roomObject.transform);
-                                    if (spawnPositionRoom == null)
-                                    {
-                                        spawnPositionRoom = instantiateRoom;
-                                        _spawnPosition = instantiatePosition;
-                                    }
                                 }
                                 break;
                             case RoomType.room2x2Stair:
@@ -368,13 +361,9 @@ namespace Scenes.Ingame.Stage
             int inputRoomId = updateRoomId ? 1 + _roomId++ : stage[(int)plotPosition.x, (int)plotPosition.y].RoomId;
 
             Vector2 plotRoomSize = Vector2.one;
-            int plotX = (int)plotPosition.x;
-            int plotY = (int)plotPosition.y;
             switch (plotRoomType)
             {
                 case RoomType.room2x2:
-                    plotRoomSize = ToVector2(2, 2);
-                    break;
                 case RoomType.room2x2Stair:
                     plotRoomSize = ToVector2(2, 2);
                     break;
@@ -385,8 +374,6 @@ namespace Scenes.Ingame.Stage
                     plotRoomSize = ToVector2(3, 2);
                     break;
                 case RoomType.room3x3:
-                    plotRoomSize = ToVector2(3, 3);
-                    break;
                 case RoomType.room3x3Stair:
                     plotRoomSize = ToVector2(3, 3);
                     break;
@@ -406,7 +393,7 @@ namespace Scenes.Ingame.Stage
             {
                 for (int x = 0; x < plotRoomSize.x; x++)
                 {
-                    stage[plotX + x, plotY + y].RoomDataSet(plotRoomType, inputRoomId);
+                    stage[(int)plotPosition.x + x, (int)plotPosition.y + y].RoomDataSet(plotRoomType, inputRoomId);
                 }
             }
         }
@@ -417,7 +404,6 @@ namespace Scenes.Ingame.Stage
         private List<Vector2> candidatePositionSet(RoomData[,] stage, int offsetX = 1, int offsetY = 1)
         {
             List<Vector2> candidatePositions = new List<Vector2>();
-            Vector2 setPosition = Vector2.zero;
             for (int y = 0; y < _stageSize.y - offsetY; y++)
             {
                 for (int x = 0; x < _stageSize.x - offsetX; x++)
@@ -427,8 +413,7 @@ namespace Scenes.Ingame.Stage
                         RoomIdEqual(ToVector2(x, y), ToVector2(offsetX, 0), 0, stage) &&
                         RoomIdEqual(ToVector2(x, y), ToVector2(offsetX, offsetY), 0, stage))
                     {
-                        setPosition = ToVector2(x, y);
-                        candidatePositions.Add(setPosition);
+                        candidatePositions.Add(ToVector2(x, y));
                     }
                 }
             }
@@ -442,7 +427,6 @@ namespace Scenes.Ingame.Stage
         {
             if (offsetX == 0 && offsetY == 0) Debug.LogError("offsetの値が両方とも0です");
             List<Vector2> candidatePositions = new List<Vector2>();
-            Vector2 setPosition = Vector2.zero;
             for (int y = 0; y < _stageSize.y - offsetY; y++)
             {
                 for (int x = 0; x < _stageSize.x - offsetX; x++)
@@ -474,8 +458,7 @@ namespace Scenes.Ingame.Stage
                                 if (RoomIdEqual(ToVector2(x, y), ToVector2(1, 0), 0, stage)) continue;
                             }
                         }
-                        setPosition = ToVector2(x, y);
-                        candidatePositions.Add(setPosition);
+                        candidatePositions.Add(ToVector2(x, y));
                     }
                 }
             }
@@ -489,7 +472,6 @@ namespace Scenes.Ingame.Stage
         {
             if (offsetX == 0 && offsetY == 0) Debug.LogError("offsetの値が両方とも0です");
             List<Vector2> candidatePositions = new List<Vector2>();
-            Vector2 setPosition = Vector2.zero;
             for (int y = 0; y < _stageSize.y - offsetY; y++)
             {
                 for (int x = 0; x < _stageSize.x - offsetX; x++)
@@ -517,8 +499,7 @@ namespace Scenes.Ingame.Stage
                     }
                     if (existCorridor)
                     {
-                        setPosition = ToVector2(x, y);
-                        candidatePositions.Add(setPosition);
+                        candidatePositions.Add(ToVector2(x, y));
                     }
                 }
             }
@@ -532,7 +513,6 @@ namespace Scenes.Ingame.Stage
         {
             if (offsetX != 0 && offsetY != 0) { Debug.LogError("無効な引数です。どちらかを0にしてください"); }
             List<Vector2> candidatePositions = new List<Vector2>();
-            Vector2 setPosition = Vector2.zero;
             int xLength = stage.GetLength(0);
             int yLength = stage.GetLength(1);
             for (int y = 0; y < yLength - offsetY; y++)
@@ -541,34 +521,21 @@ namespace Scenes.Ingame.Stage
                 {
                     if (stage[x, y].RoomId == 0)
                     {
-                        if (offsetX != 0)
+                        try
                         {
-                            if (x < xLength - 1 && offsetX > 0)
+                            if (stage[x + offsetX, y + offsetY].RoomId == 0)
                             {
-                                if (stage[x + offsetX, y].RoomId == 0) continue;
+                                continue;
                             }
-                            else if (x + offsetX >= 0)
+                            if (targetRoomId == 0 || stage[x + offsetX, y + offsetY].RoomId == targetRoomId)//TODO:あとで上の条件式に入れたい
                             {
-                                if (stage[x + offsetX, y].RoomId == 0) continue;
+                                candidatePositions.Add(ToVector2(x + offsetX, y));
                             }
                         }
-                        if (offsetY != 0)
+                        catch (Exception ex)
                         {
-                            if (y < yLength - 1 && offsetY > 0)
-                            {
-                                if (stage[x, y + offsetY].RoomId == 0) continue;
-                            }
-                            else if (y - offsetY >= 0)
-                            {
-                                if (stage[x, y + offsetY].RoomId == 0) continue;
-                            }
+                            continue;
                         }
-                        if (targetRoomId == 0 || stage[x + offsetX, y + offsetY].RoomId == targetRoomId)//TODO:あとで上の条件式に入れたい
-                        {
-                            setPosition = ToVector2(x + offsetX, y);
-                            candidatePositions.Add(setPosition);
-                        }
-
                     }
                 }
             }
@@ -914,14 +881,10 @@ namespace Scenes.Ingame.Stage
                                         Instantiate(marker, instantiatePosition, Quaternion.identity);
                                     }
 
-                                    //隣接している部屋の名前をIDと一緒に記憶させる
-                                    var targetRoomName = (stage[x + (int)item.x, y + (int)item.y].RoomId);
-                                    var thisRoomName = (stage[x, y].RoomId);
-
                                     //リストに追加
-                                    roomName.Add(targetRoomName);
-                                    linqData[i].SetLinqRoomData(targetRoomName);
-                                    linqData[stage[x + (int)item.x, y + (int)item.y].RoomId].SetLinqRoomData(thisRoomName);
+                                    roomName.Add(stage[x + (int)item.x, y + (int)item.y].RoomId);
+                                    linqData[i].SetLinqRoomData(stage[x + (int)item.x, y + (int)item.y].RoomId);
+                                    linqData[stage[x + (int)item.x, y + (int)item.y].RoomId].SetLinqRoomData(stage[x, y].RoomId);
                                 }
                             }
                         }
@@ -971,10 +934,8 @@ namespace Scenes.Ingame.Stage
             foreach (var xDoor in _xSideDoorPos)
             {
                 // linqDataに登録
-                var targetRoomName = stage[(int)xDoor.x, (int)xDoor.y].RoomId;
-                var thisRoomName = stage[(int)xDoor.x - 1, (int)xDoor.y].RoomId;
-                linqData[stage[(int)xDoor.x, (int)xDoor.y].RoomId].SetLinqRoomData(thisRoomName);
-                linqData[stage[(int)xDoor.x - 1, (int)xDoor.y].RoomId].SetLinqRoomData(targetRoomName);
+                linqData[stage[(int)xDoor.x, (int)xDoor.y].RoomId].SetLinqRoomData(stage[(int)xDoor.x - 1, (int)xDoor.y].RoomId);
+                linqData[stage[(int)xDoor.x - 1, (int)xDoor.y].RoomId].SetLinqRoomData(stage[(int)xDoor.x, (int)xDoor.y].RoomId);
 
                 // オブジェクトの生成
                 instantiatePosition = ToVector3(xDoor.x * TILESIZE, floor * 5.8f, xDoor.y * TILESIZE);
@@ -989,10 +950,8 @@ namespace Scenes.Ingame.Stage
             foreach (var yDoor in _ySideDoorPos)
             {
                 // linqDataに登録
-                var targetRoomName = stage[(int)yDoor.x, (int)yDoor.y].RoomId;
-                var thisRoomName = stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId;
-                linqData[stage[(int)yDoor.x, (int)yDoor.y].RoomId].SetLinqRoomData(thisRoomName);
-                linqData[stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId].SetLinqRoomData(targetRoomName);
+                linqData[stage[(int)yDoor.x, (int)yDoor.y].RoomId].SetLinqRoomData(stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId);
+                linqData[stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId].SetLinqRoomData(stage[(int)yDoor.x, (int)yDoor.y].RoomId);
 
                 //Debug.Log($"追加のy壁生成次の隣接データ {stage[(int)yDoor.x, (int)yDoor.y].RoomId} : {stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId}");
                 // オブジェクトの生成
@@ -1112,16 +1071,13 @@ namespace Scenes.Ingame.Stage
         {
             List<GameObject> result = new List<GameObject>();
 
-            // 親オブジェクトのすべての子オブジェクトを取得
             foreach (Transform child in parent)
             {
-                // 子オブジェクトが指定されたタグを持つか確認
                 if (child.CompareTag(tag))
                 {
                     result.Add(child.gameObject);
                 }
 
-                // 子オブジェクトの子オブジェクトも再帰的に検索
                 result.AddRange(FindChildrenByTag(child, tag));
             }
 
@@ -1141,19 +1097,14 @@ namespace Scenes.Ingame.Stage
                         continue;
                     }
                     if (floor1fData[x, y].RoomType == RoomType.room2x2 &&
-                        floor1fData[x, y].RoomId == floor1fData[x + 1, y].RoomId &&
-                        floor1fData[x, y].RoomId == floor1fData[x, y + 1].RoomId)
+                        floor2fData[x, y].RoomType == RoomType.room2x2 &&
+                        RoomIdEqual(ToVector2(x, y), ToVector2(1, 1), floor1fData[x, y].RoomId, floor1fData) &&
+                        RoomIdEqual(ToVector2(x, y), ToVector2(1, 1), floor1fData[x, y].RoomId, floor2fData))
                     {
-                        if (floor2fData[x, y].RoomType == RoomType.room2x2 &&
-                            floor2fData[x, y].RoomId == floor2fData[x + 1, y].RoomId &&
-                            floor2fData[x, y].RoomId == floor2fData[x, y + 1].RoomId)
-                        {
                             RoomPlotId(RoomType.room2x2Stair, new Vector2(x, y), floor1fData, updateRoomId: false);
                             RoomPlotId(RoomType.room2x2Stair, new Vector2(x, y), floor2fData, updateRoomId: false);
 
                             _stairPosition.Add(ToVector2(x + 1, y + 1));
-                            if (viewDebugLog) Debug.Log("2x2階段の部屋に適した場所あり");
-                        }
                     }
                     //3x3のstairRoomについて
                     if (y > floor1fData.GetLength(1) - 3 || x > floor1fData.GetLength(0) - 3)//ステージ端からOFFSET分しか計算しないようにするチェック
@@ -1161,19 +1112,14 @@ namespace Scenes.Ingame.Stage
                         continue;
                     }
                     if (floor1fData[x, y].RoomType == RoomType.room3x3 &&
-                        floor1fData[x, y].RoomId == floor1fData[x + 2, y].RoomId &&
-                        floor1fData[x, y].RoomId == floor1fData[x, y + 2].RoomId)
+                        floor2fData[x, y].RoomType == RoomType.room3x3 &&
+                        RoomIdEqual(ToVector2(x, y), ToVector2(2, 2), floor1fData[x, y].RoomId, floor1fData) &&
+                        RoomIdEqual(ToVector2(x, y), ToVector2(2, 2), floor1fData[x, y].RoomId, floor2fData))
                     {
-                        if (floor2fData[x, y].RoomType == RoomType.room3x3 &&
-                            floor2fData[x, y].RoomId == floor2fData[x + 2, y].RoomId &&
-                            floor2fData[x, y].RoomId == floor2fData[x, y + 2].RoomId)
-                        {
                             RoomPlotId(RoomType.room3x3Stair, new Vector2(x, y), floor1fData, updateRoomId: false);
                             RoomPlotId(RoomType.room3x3Stair, new Vector2(x, y), floor2fData, updateRoomId: false);
 
                             _stairPosition.Add(ToVector2(x + 2, y + 2));
-                            if (viewDebugLog) Debug.Log("3x3階段の部屋に適した場所あり");
-                        }
                     }
                 }
             }
@@ -1188,10 +1134,8 @@ namespace Scenes.Ingame.Stage
                     if ((floor1fData[x, y].RoomType == RoomType.room2x2Stair && floor2fData[x, y].RoomType == RoomType.room2x2Stair)
                         || (floor1fData[x, y].RoomType == RoomType.room3x3Stair && floor2fData[x, y].RoomType == RoomType.room3x3Stair))
                     {
-                        var targetRoomName = floor2fData[x, y].RoomId;
-                        var thisRoomName = floor1fData[x, y].RoomId;
-                        linqData[floor2fData[x, y].RoomId].SetLinqRoomData(thisRoomName);
-                        linqData[floor1fData[x, y].RoomId].SetLinqRoomData(targetRoomName);
+                        linqData[floor2fData[x, y].RoomId].SetLinqRoomData(floor1fData[x, y].RoomId);
+                        linqData[floor1fData[x, y].RoomId].SetLinqRoomData(floor2fData[x, y].RoomId);
                     }
 
                 }
@@ -1199,7 +1143,6 @@ namespace Scenes.Ingame.Stage
         }
 
         Vector2 translation2 = Vector2.zero;
-        Vector3 translation3 = Vector3.zero;
         private Vector2 ToVector2(float x, float y)
         {
             translation2.x = x;
@@ -1207,6 +1150,7 @@ namespace Scenes.Ingame.Stage
             return translation2;
         }
 
+        Vector3 translation3 = Vector3.zero;
         private Vector3 ToVector3(float x, float y, float z)
         {
             translation3.x = x;
@@ -1215,9 +1159,9 @@ namespace Scenes.Ingame.Stage
             return translation3;
         }
 
-        private bool RoomIdEqual(Vector2 basePosition, Vector2 position1, int roomId, RoomData[,] stage)
+        private bool RoomIdEqual(Vector2 basePosition, Vector2 addPosition, int roomId, RoomData[,] stage)
         {
-            if (stage[(int)(basePosition.x + position1.x), (int)(basePosition.y + position1.y)].RoomId == roomId)
+            if (stage[(int)(basePosition.x + addPosition.x), (int)(basePosition.y + addPosition.y)].RoomId == roomId)
             {
                 return true;
             }

--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -29,7 +29,6 @@ namespace Scenes.Ingame.Stage
         private List<Vector2> candidatePosition = new List<Vector2>();
         private RoomData[,] _firsrFloorData;
         private RoomData[,] _secondFloorData;
-        private List<GameObject> instantiateRooms = new List<GameObject>();
         private GameObject spawnPositionRoom = null;
         private GameObject instantiateRoom;
         private int _roomId = 0;
@@ -308,8 +307,8 @@ namespace Scenes.Ingame.Stage
                         if(stage[x, y].RoomType != RoomType.none)
                         {
                             stage[x, y].SetRoomName(instantiateRoom.name);  //生成した部屋の情報に部屋の名前を追加
+                            stage[x, y].SetGameObject(instantiateRoom);
                         }
-                        instantiateRooms.Add(instantiateRoom);
                     }
                 }
             }

--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -909,7 +909,7 @@ namespace Scenes.Ingame.Stage
                                 if (stage[x, y].RoomId != stage[x + (int)item.x, y + (int)item.y].RoomId)
                                 {
                                     var instantiatePosition = ToVector3((x + (int)item.x) * TILESIZE, floor * 5.84f, (y + (int)item.y) * TILESIZE);
-                                    if(marker != null)
+                                    if(marker != null && viewDebugLog)
                                     {
                                         Instantiate(marker, instantiatePosition, Quaternion.identity);
                                     }
@@ -977,7 +977,7 @@ namespace Scenes.Ingame.Stage
                 // オブジェクトの生成
                 instantiatePosition = ToVector3(xDoor.x * TILESIZE, floor * 5.8f, xDoor.y * TILESIZE);
                 Instantiate(_prefabPool.getWallXDoorPrefab, instantiatePosition, Quaternion.identity, inSideWallObject.transform);
-                if (markerRed != null)
+                if (markerRed != null && viewDebugLog)
                 {
                     instantiatePosition = ToVector3(xDoor.x * TILESIZE, floor * 5.84f, xDoor.y * TILESIZE);
                     Instantiate(markerRed, instantiatePosition, Quaternion.identity);
@@ -996,7 +996,7 @@ namespace Scenes.Ingame.Stage
                 // オブジェクトの生成
                 instantiatePosition = ToVector3(yDoor.x * TILESIZE, floor * 5.8f, yDoor.y * TILESIZE);
                 Instantiate(_prefabPool.getWallYDoorPrefab, instantiatePosition, Quaternion.identity, inSideWallObject.transform);
-                if(markerRed != null)
+                if(markerRed != null && viewDebugLog)
                 {
                     instantiatePosition = ToVector3(yDoor.x * TILESIZE, floor * 5.84f, (yDoor.y + 1) * TILESIZE);
                     Instantiate(markerRed, instantiatePosition, Quaternion.identity);

--- a/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
+++ b/Assets/Scripts/Scenes/InGame/Stage/StageGenerator.cs
@@ -132,7 +132,7 @@ namespace Scenes.Ingame.Stage
             {
                 RoomData[,] targetFloor = floor == 1 ? _firsrFloorData : _secondFloorData;
                 await GenerateStage(token, targetFloor, floor - 1);                             //部屋の生成
-                
+
                 await CorridorShaping(token, targetFloor, floor - 1);                         //通路の装飾
 
                 await LinqBaseGenerateWall(token, targetFloor, floor - 1);                                 //新しい隣接している壁の計算
@@ -140,7 +140,7 @@ namespace Scenes.Ingame.Stage
             }
             StairConnectLinqRoom(_firsrFloorData, _secondFloorData);
             ErrorCheck();
-            if(AreAllRoomsConnected())
+            if (AreAllRoomsConnected())
             {
                 Debug.Log($"All Room linqed Success!");
             }
@@ -148,7 +148,7 @@ namespace Scenes.Ingame.Stage
             {
                 Debug.LogWarning($"All Room linqed Failed!");
             }
-            
+
             floorNavMeshSurface.BuildNavMesh();
             IngameManager.Instance.SetReady(ReadyEnum.StageReady);
         }
@@ -254,7 +254,7 @@ namespace Scenes.Ingame.Stage
                                 else
                                 {
                                     instantiateRoom = Instantiate(_prefabPool.get2x2RoomPrefab[UnityEngine.Random.Range(0, _prefabPool.get2x2RoomPrefab.Length)], instantiatePosition, Quaternion.identity, roomObject.transform);
-                                    if(spawnPositionRoom == null)
+                                    if (spawnPositionRoom == null)
                                     {
                                         spawnPositionRoom = instantiateRoom;
                                         _spawnPosition = instantiatePosition;
@@ -304,7 +304,7 @@ namespace Scenes.Ingame.Stage
                                 Debug.Log($"select not set roomtype {stage[x, y].RoomType}");
                                 break;
                         }
-                        if(stage[x, y].RoomType != RoomType.none)
+                        if (stage[x, y].RoomType != RoomType.none)
                         {
                             stage[x, y].SetRoomName(instantiateRoom.name);  //生成した部屋の情報に部屋の名前を追加
                             stage[x, y].SetGameObject(instantiateRoom);
@@ -363,7 +363,7 @@ namespace Scenes.Ingame.Stage
         /// <param name="plotRoomSize">ルームの大きさ</param>
         /// <param name="plotPosition">ルームの設定位置</param>
         /// <param name="updateRoomId">RoomIdを更新するかどうか</param>
-        private void RoomPlotId(RoomType plotRoomType, Vector2 plotPosition, RoomData[,] stage,bool updateRoomId = true)
+        private void RoomPlotId(RoomType plotRoomType, Vector2 plotPosition, RoomData[,] stage, bool updateRoomId = true)
         {
             int inputRoomId = updateRoomId ? 1 + _roomId++ : stage[(int)plotPosition.x, (int)plotPosition.y].RoomId;
 
@@ -528,7 +528,7 @@ namespace Scenes.Ingame.Stage
         /// <summary>
         /// 次の場所は壁のタイルを検索するための関数
         /// </summary>
-        private List<Vector2> candidateNextWallPosition(RoomData[,] stage, int offsetX = 0, int offsetY = 0,int targetRoomId = 0)
+        private List<Vector2> candidateNextWallPosition(RoomData[,] stage, int offsetX = 0, int offsetY = 0, int targetRoomId = 0)
         {
             if (offsetX != 0 && offsetY != 0) { Debug.LogError("無効な引数です。どちらかを0にしてください"); }
             List<Vector2> candidatePositions = new List<Vector2>();
@@ -563,7 +563,7 @@ namespace Scenes.Ingame.Stage
                                 if (stage[x, y + offsetY].RoomId == 0) continue;
                             }
                         }
-                        if(targetRoomId == 0 || stage[x + offsetX, y + offsetY].RoomId == targetRoomId)//TODO:あとで上の条件式に入れたい
+                        if (targetRoomId == 0 || stage[x + offsetX, y + offsetY].RoomId == targetRoomId)//TODO:あとで上の条件式に入れたい
                         {
                             setPosition = ToVector2(x + offsetX, y);
                             candidatePositions.Add(setPosition);
@@ -596,29 +596,29 @@ namespace Scenes.Ingame.Stage
                     newStageGenerateData[i, j] = initialData;
                 }
             }
-                //X軸を通路分ずらす処理
-                for (int y = 0; y < stage.GetLength(1); y++)
+            //X軸を通路分ずらす処理
+            for (int y = 0; y < stage.GetLength(1); y++)
+            {
+                xSlide = false;
+                for (int x = 0; x < stage.GetLength(0); x++)
                 {
-                    xSlide = false;
-                    for (int x = 0; x < stage.GetLength(0); x++)
+                    if (xSlide == false)
                     {
-                        if (xSlide == false)
+                        if (x >= xAisleNumber && stage[x, y].RoomId != stage[x - 1, y].RoomId)
                         {
-                            if (x >= xAisleNumber && stage[x, y].RoomId != stage[x - 1, y].RoomId)
-                            {
-                                xSlide = true;
-                            }
-                        }
-                        if (xSlide)
-                        {
-                            newStageGenerateData[x + 1, y] = stage[x, y];
-                        }
-                        else
-                        {
-                            newStageGenerateData[x, y] = stage[x, y];
+                            xSlide = true;
                         }
                     }
+                    if (xSlide)
+                    {
+                        newStageGenerateData[x + 1, y] = stage[x, y];
+                    }
+                    else
+                    {
+                        newStageGenerateData[x, y] = stage[x, y];
+                    }
                 }
+            }
             var tempXPlotData = new RoomData[newStageGenerateData.GetLength(0), newStageGenerateData.GetLength(1)];
             for (int i = 0; i < (int)_stageSize.y + 1; i++)
             {
@@ -627,26 +627,26 @@ namespace Scenes.Ingame.Stage
                     tempXPlotData[i, j] = initialData;
                 }
             }
-                //y軸を通路分ずらす処理
-                for (int x = 0; x < newStageGenerateData.GetLength(0); x++)
+            //y軸を通路分ずらす処理
+            for (int x = 0; x < newStageGenerateData.GetLength(0); x++)
+            {
+                ySlide = false;
+                for (int y = 0; y < newStageGenerateData.GetLength(1) - 1; y++)
                 {
-                    ySlide = false;
-                    for (int y = 0; y < newStageGenerateData.GetLength(1) - 1; y++)
+                    if (y >= yAisleNumber && newStageGenerateData[x, y].RoomId != newStageGenerateData[x, y - 1].RoomId)
                     {
-                        if (y >= yAisleNumber && newStageGenerateData[x, y].RoomId != newStageGenerateData[x, y - 1].RoomId)
-                        {
-                            ySlide = true;
-                        }
-                        if (ySlide)
-                        {
-                            tempXPlotData[x, y + 1] = newStageGenerateData[x, y];
-                        }
-                        else
-                        {
-                            tempXPlotData[x, y] = newStageGenerateData[x, y];
-                        }
+                        ySlide = true;
+                    }
+                    if (ySlide)
+                    {
+                        tempXPlotData[x, y + 1] = newStageGenerateData[x, y];
+                    }
+                    else
+                    {
+                        tempXPlotData[x, y] = newStageGenerateData[x, y];
                     }
                 }
+            }
             return tempXPlotData;
         }
 
@@ -878,7 +878,7 @@ namespace Scenes.Ingame.Stage
         /// <summary>
         ///  隣接する部屋の計算
         /// </summary>
-        private async UniTask LinqBaseGenerateWall(CancellationToken token, RoomData[,] stage,int floor)
+        private async UniTask LinqBaseGenerateWall(CancellationToken token, RoomData[,] stage, int floor)
         {
             int roomIdMax = stage.Cast<RoomData>().Select(rt => rt.RoomId).Max();
             int roomIdMin = stage.Cast<RoomData>()
@@ -886,7 +886,7 @@ namespace Scenes.Ingame.Stage
                                   .Where(id => id != 0)
                                   .DefaultIfEmpty(int.MaxValue)  // すべての要素が0の場合に備える
                                   .Min();
-            if(viewDebugLog)
+            if (viewDebugLog)
             {
                 Debug.Log($"Min = {roomIdMin},Max = {roomIdMax}");
             }
@@ -909,7 +909,7 @@ namespace Scenes.Ingame.Stage
                                 if (stage[x, y].RoomId != stage[x + (int)item.x, y + (int)item.y].RoomId)
                                 {
                                     var instantiatePosition = ToVector3((x + (int)item.x) * TILESIZE, floor * 5.84f, (y + (int)item.y) * TILESIZE);
-                                    if(marker != null && viewDebugLog)
+                                    if (marker != null && viewDebugLog)
                                     {
                                         Instantiate(marker, instantiatePosition, Quaternion.identity);
                                     }
@@ -933,7 +933,7 @@ namespace Scenes.Ingame.Stage
         /// <summary>
         /// 壁を設置するスクリプト
         /// </summary>
-        private async UniTask GenerateWall(CancellationToken token, RoomData[,] stage, int floor,int xDoorParameter = 0,int yDoorParameter = 0)
+        private async UniTask GenerateWall(CancellationToken token, RoomData[,] stage, int floor, int xDoorParameter = 0, int yDoorParameter = 0)
         {
             Vector3 instantiatePosition = Vector3.zero;
             _xSideWallPos = candidateNextWallPosition(stage, offsetX: 1);
@@ -949,7 +949,7 @@ namespace Scenes.Ingame.Stage
                                   .DefaultIfEmpty(int.MaxValue)  // すべての要素が0の場合に備える
                                   .Min();
 
-            foreach (var item in linqData.Where(d => (d.Value.linqData.Count < 2 || (d.Value.linqData.Count < 3 && largeRoom(stage.Cast<RoomData>().FirstOrDefault(s => s.RoomId ==d.Key).RoomType)))
+            foreach (var item in linqData.Where(d => (d.Value.linqData.Count < 2 || (d.Value.linqData.Count < 3 && largeRoom(stage.Cast<RoomData>().FirstOrDefault(s => s.RoomId == d.Key).RoomType)))
                                                     && d.Key <= roomIdMax
                                                     && d.Key >= roomIdMin).ToList())
             {
@@ -961,7 +961,7 @@ namespace Scenes.Ingame.Stage
                     _xSideDoorPos.Add(doorXsideInstallablePosition);
                     _xSideWallPos.Remove(doorXsideInstallablePosition);
                 }
-                else if(doorYsideInstallablePositions.Count != 0)
+                else if (doorYsideInstallablePositions.Count != 0)
                 {
                     var doorYsideInstallablePosition = doorYsideInstallablePositions[UnityEngine.Random.Range(0, doorYsideInstallablePositions.Count)];
                     _ySideDoorPos.Add(doorYsideInstallablePosition);
@@ -990,7 +990,7 @@ namespace Scenes.Ingame.Stage
             {
                 // linqDataに登録
                 var targetRoomName = stage[(int)yDoor.x, (int)yDoor.y].RoomId;
-                var thisRoomName = stage[(int)yDoor.x , (int)yDoor.y + 1].RoomId;
+                var thisRoomName = stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId;
                 linqData[stage[(int)yDoor.x, (int)yDoor.y].RoomId].SetLinqRoomData(thisRoomName);
                 linqData[stage[(int)yDoor.x, (int)yDoor.y + 1].RoomId].SetLinqRoomData(targetRoomName);
 
@@ -998,7 +998,7 @@ namespace Scenes.Ingame.Stage
                 // オブジェクトの生成
                 instantiatePosition = ToVector3(yDoor.x * TILESIZE, floor * 5.8f, yDoor.y * TILESIZE);
                 Instantiate(_prefabPool.getWallYDoorPrefab, instantiatePosition, Quaternion.identity, inSideWallObject.transform);
-                if(markerRed != null && viewDebugLog)
+                if (markerRed != null && viewDebugLog)
                 {
                     instantiatePosition = ToVector3(yDoor.x * TILESIZE, floor * 5.84f, (yDoor.y + 1) * TILESIZE);
                     Instantiate(markerRed, instantiatePosition, Quaternion.identity);
@@ -1063,7 +1063,7 @@ namespace Scenes.Ingame.Stage
                 nonVisited = nonVisited.Except(visited).ToHashSet();
                 nonCount = nonVisited.Count;
             }
-            if(viewDebugLog)
+            if (viewDebugLog)
             {
                 String connected = "AreAllRoomsConnected : 連続していた部屋は ";
                 foreach (int adjacentRoom in visited)
@@ -1073,7 +1073,7 @@ namespace Scenes.Ingame.Stage
                 Debug.Log(connected);
             }
 
-            if(viewDebugLog)
+            if (viewDebugLog)
             {
                 Debug.Log($"AreAllRoomsConnected : 連続していた部屋の数は {visited.Count} : {nonVisited.Count},linqData = {linqData.Count},maxRoomCount = {_roomId}");
 
@@ -1097,7 +1097,7 @@ namespace Scenes.Ingame.Stage
                 foreach (var item in except)
                 {
                     var roomObject = allData.FirstOrDefault(d => d.RoomId == item).gameObject;
-                    var itemSpawnPoints = FindChildrenByTag(roomObject.transform,"ItemSpawnPoint");
+                    var itemSpawnPoints = FindChildrenByTag(roomObject.transform, "ItemSpawnPoint");
                     for (int i = 0; i < itemSpawnPoints.Length; i++)
                     {
                         Destroy(itemSpawnPoints[i]);
@@ -1185,7 +1185,7 @@ namespace Scenes.Ingame.Stage
             {
                 for (int x = 0; x < floor1fData.GetLength(0); x++)
                 {
-                    if((floor1fData[x, y].RoomType == RoomType.room2x2Stair && floor2fData[x, y].RoomType == RoomType.room2x2Stair)
+                    if ((floor1fData[x, y].RoomType == RoomType.room2x2Stair && floor2fData[x, y].RoomType == RoomType.room2x2Stair)
                         || (floor1fData[x, y].RoomType == RoomType.room3x3Stair && floor2fData[x, y].RoomType == RoomType.room3x3Stair))
                     {
                         var targetRoomName = floor2fData[x, y].RoomId;
@@ -1193,7 +1193,7 @@ namespace Scenes.Ingame.Stage
                         linqData[floor2fData[x, y].RoomId].SetLinqRoomData(thisRoomName);
                         linqData[floor1fData[x, y].RoomId].SetLinqRoomData(targetRoomName);
                     }
-                    
+
                 }
             }
         }


### PR DESCRIPTION
## 概要
<!--
追加した機能について記入してください。
-->
ステージ生成の軽量化を行った
NavMeshを使わない経路計算の方法に変更
## 変更点
<!--
変更した箇所について記入してください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
- 経路計算方法の変更
- ドアの設置計算の変更
- 到達不可の部屋が発生した場合の処理の追加

## テスト
 <!-- 
 動作テストを行うシーン名を下記のように書いてください。
  動作確認用シーン：Ingame_Player
 -->
Ingame_Stage
※マップは作業の都合上ずっと霧がかかってないです
 動作確認用シーン：
<!--
プッシュする前に下記のことを確認したかを確かめてください。確認した場合はチェックを付けてください。
※チェックの付け方 []を[x]とする。
-->
 - [] 複雑であったり、わかりにくい部分のコメントアウトでの説明
 - [x] 命名規則の統一
 - [x] 変更箇所にエラーが発生してるかの確認
 - [] ビルドが成功するかの確認
## 問題
<!--
現状なにか問題が発生している場合はこちらに書いてください。書き方は下記のような箇条書きで行ってください。
- 変更点1
- 変更点2
- 変更点3
-->
メモ：全ての部屋が到達可能な場合コンソールに「All Room linqed Success!」とログが出ます。
全ての部屋が到達不可の場合コンソールに「All Room linqed Failed!」と表示され、到達不可の部屋にはアイテムがわかないように処理されます。
※現在はアセットとNavmeshの影響でRuntimeNavMeshBuilder: Source mesh 〜〜〜 does not allow read access. がエラーとして発生しますが、当作業とは関係ありません。
※現在ItemGeneratorがIndexOutOfRangeException: Index was outside the bounds of the array.のエラーを発しますが、当作業とは関係ありません。