### PR TITLE
痕跡対応表部屋プレハブの作成

### DIFF
--- a/Assets/Resources/Materials/tempTraseItem.mat
+++ b/Assets/Resources/Materials/tempTraseItem.mat
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!114 &-4007006071853390602
+--- !u!114 &-6978147977505401743
 MonoBehaviour:
   m_ObjectHideFlags: 11
   m_CorrespondingSourceObject: {fileID: 0}
@@ -23,25 +23,22 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Rack
+  m_Name: tempTraseItem
   m_Shader: {fileID: 4800000, guid: 6e4ae4064600d784cac1e41a9e6f2e59, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _DISABLE_SSR_TRANSPARENT
-  - _DISPLACEMENT_LOCK_TILING_SCALE
-  - _HEIGHTMAP
-  - _MASKMAP
-  - _NORMALMAP
+  - _ENABLE_FOG_ON_TRANSPARENT
   - _NORMALMAP_TANGENT_SPACE
-  - _PIXEL_DISPLACEMENT
-  - _PIXEL_DISPLACEMENT_LOCK_OBJECT_SCALE
+  - _SURFACE_TYPE_TRANSPARENT
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2225
-  stringTagMap: {}
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses:
   - TransparentDepthPrepass
   - TransparentDepthPostpass
@@ -57,7 +54,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BaseColorMap:
-        m_Texture: {fileID: 2800000, guid: 716afd6b4985d8d47bdd6b39d354ed9e, type: 3}
+        m_Texture: {fileID: 2800000, guid: 9a7ed99e3b9b54949b02db649e97119a, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _BentNormalMap:
@@ -68,31 +65,11 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _BumpMap:
-        m_Texture: {fileID: 2800000, guid: ad7272c4d6b8bed4dbd6010d7af398df, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _CoatMaskMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _DetailAlbedoMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _DetailMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailMask:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailNormalMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -101,7 +78,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _HeightMap:
-        m_Texture: {fileID: 2800000, guid: 92274f4767f655743a847376457a2c4e, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _IridescenceMaskMap:
@@ -113,31 +90,19 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 716afd6b4985d8d47bdd6b39d354ed9e, type: 3}
+        m_Texture: {fileID: 2800000, guid: 9a7ed99e3b9b54949b02db649e97119a, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MaskMap:
-        m_Texture: {fileID: 2800000, guid: 3e69017752bd4154a89bbbf450a80c22, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 2800000, guid: 0dadcd99398f1024ab8ededd644911b1, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _NormalMap:
-        m_Texture: {fileID: 2800000, guid: ad7272c4d6b8bed4dbd6010d7af398df, type: 3}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _NormalMapOS:
         m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 2800000, guid: cd78e1525c9ea6e4e889a902795294d8, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _ParallaxMap:
-        m_Texture: {fileID: 2800000, guid: 92274f4767f655743a847376457a2c4e, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _SpecularColorMap:
@@ -183,7 +148,7 @@ Material:
     m_Ints: []
     m_Floats:
     - _AORemapMax: 1
-    - _AORemapMin: 0.5
+    - _AORemapMin: 0
     - _ATDistance: 1
     - _AddPrecomputedVelocity: 0
     - _AlbedoAffectEmissive: 0
@@ -192,31 +157,29 @@ Material:
     - _AlphaCutoffPostpass: 0.5
     - _AlphaCutoffPrepass: 0.5
     - _AlphaCutoffShadow: 0.5
-    - _AlphaDstBlend: 0
+    - _AlphaDstBlend: 10
     - _AlphaRemapMax: 1
     - _AlphaRemapMin: 0
     - _AlphaSrcBlend: 1
     - _Anisotropy: 0
     - _BlendMode: 0
-    - _BumpScale: 1
     - _CoatMask: 0
     - _CullMode: 2
     - _CullModeForward: 2
     - _Cutoff: 0.5
     - _DepthOffsetEnable: 0
     - _DetailAlbedoScale: 1
-    - _DetailNormalMapScale: 1
     - _DetailNormalScale: 1
     - _DetailSmoothnessScale: 1
     - _DiffusionProfile: 0
     - _DiffusionProfileHash: 0
     - _DisplacementLockObjectScale: 1
     - _DisplacementLockTilingScale: 1
-    - _DisplacementMode: 2
+    - _DisplacementMode: 0
     - _DoubleSidedEnable: 0
     - _DoubleSidedGIMode: 0
     - _DoubleSidedNormalMode: 1
-    - _DstBlend: 0
+    - _DstBlend: 10
     - _EmissiveColorMode: 1
     - _EmissiveExposureWeight: 1
     - _EmissiveIntensity: 1
@@ -225,64 +188,56 @@ Material:
     - _EnableFogOnTransparent: 1
     - _EnableGeometricSpecularAA: 0
     - _EnergyConservingSpecularColor: 1
-    - _GlossMapScale: 0.4
-    - _Glossiness: 0.5
-    - _GlossyReflections: 1
-    - _HeightAmplitude: 0.0001
-    - _HeightCenter: 1
+    - _HeightAmplitude: 0.02
+    - _HeightCenter: 0.5
     - _HeightMapParametrization: 0
     - _HeightMax: 1
     - _HeightMin: -1
     - _HeightOffset: 0
-    - _HeightPoMAmplitude: 0.01
+    - _HeightPoMAmplitude: 2
     - _HeightTessAmplitude: 2
     - _HeightTessCenter: 0.5
     - _InvTilingScale: 1
     - _Ior: 1.5
     - _IridescenceMask: 1
     - _IridescenceThickness: 1
-    - _LinkDetailsWithBase: 0
+    - _LinkDetailsWithBase: 1
     - _MaterialID: 1
     - _Metallic: 1
     - _MetallicRemapMax: 1
     - _MetallicRemapMin: 0
-    - _Mode: 0
     - _NormalMapSpace: 0
     - _NormalScale: 1
     - _ObjectSpaceUVMapping: 0
     - _ObjectSpaceUVMappingEmissive: 0
-    - _OcclusionStrength: 0.5
     - _OpaqueCullMode: 2
     - _PPDLodThreshold: 5
     - _PPDMaxSamples: 15
     - _PPDMinSamples: 5
     - _PPDPrimitiveLength: 1
     - _PPDPrimitiveWidth: 1
-    - _Parallax: 0.005
     - _RayTracing: 0
     - _ReceivesSSR: 1
     - _ReceivesSSRTransparent: 0
     - _RefractionModel: 0
     - _Smoothness: 0.5
-    - _SmoothnessRemapMax: 0.4
+    - _SmoothnessRemapMax: 1
     - _SmoothnessRemapMin: 0
-    - _SmoothnessTextureChannel: 0
     - _SpecularAAScreenSpaceVariance: 0.1
     - _SpecularAAThreshold: 0.2
-    - _SpecularHighlights: 1
     - _SpecularOcclusionMode: 1
     - _SrcBlend: 1
     - _StencilRef: 0
-    - _StencilRefDepth: 8
-    - _StencilRefGBuffer: 10
-    - _StencilRefMV: 40
+    - _StencilRefDepth: 0
+    - _StencilRefGBuffer: 2
+    - _StencilRefMV: 32
     - _StencilWriteMask: 6
     - _StencilWriteMaskDepth: 9
     - _StencilWriteMaskGBuffer: 15
     - _StencilWriteMaskMV: 41
     - _SubsurfaceMask: 1
     - _SupportDecals: 1
-    - _SurfaceType: 0
+    - _SurfaceType: 1
     - _TexWorldScale: 1
     - _TexWorldScaleEmissive: 1
     - _Thickness: 1
@@ -298,17 +253,16 @@ Material:
     - _UVBase: 0
     - _UVDetail: 0
     - _UVEmissive: 0
-    - _UVSec: 0
     - _UseEmissiveIntensity: 0
     - _UseShadowThreshold: 0
-    - _ZTestDepthEqualForOpaque: 3
+    - _ZTestDepthEqualForOpaque: 4
     - _ZTestGBuffer: 4
     - _ZTestTransparent: 4
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 0.6886792, g: 0.6886792, b: 0.6886792, a: 1}
+    - _BaseColor: {r: 0, g: 0.79347765, b: 0.8584906, a: 1}
     - _BaseColorMap_MipInfo: {r: 0, g: 0, b: 0, a: 0}
-    - _Color: {r: 0.6886792, g: 0.6886792, b: 0.6886792, a: 1}
+    - _Color: {r: 0, g: 0.79347765, b: 0.8584906, a: 1}
     - _DiffusionProfileAsset: {r: 0, g: 0, b: 0, a: 0}
     - _DoubleSidedConstants: {r: 1, g: 1, b: -1, a: 0}
     - _EmissionColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Resources/Materials/tempTraseItem.mat.meta
+++ b/Assets/Resources/Materials/tempTraseItem.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffcf46ca817b5d54388e2e2f5e361c6e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefab/Stage/HorrorHouse/JournalRoom_HH.prefab
+++ b/Assets/Resources/Prefab/Stage/HorrorHouse/JournalRoom_HH.prefab
@@ -1,0 +1,7643 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1033996215267026599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 202351300519877863}
+  m_Layer: 0
+  m_Name: GameObject (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &202351300519877863
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1033996215267026599}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0.0000019669533}
+  m_LocalPosition: {x: -11.02, y: 2.0413547, z: 6.39}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 552504890823254929}
+  - {fileID: 1559515457587117234}
+  - {fileID: 8485567275623371983}
+  - {fileID: 6145513338921639726}
+  - {fileID: 282916207110327213}
+  - {fileID: 5749885974107956507}
+  - {fileID: 1886339109012568371}
+  - {fileID: 2687870393685631077}
+  - {fileID: 9061593074721041791}
+  - {fileID: 2795048111786262256}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 0}
+--- !u!1 &1404690162250995150
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 913600539750437975}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &913600539750437975
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1404690162250995150}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.8, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1562338959723880087}
+  - {fileID: 5240692152236813117}
+  - {fileID: 2497771640717321855}
+  - {fileID: 2675521313857906891}
+  - {fileID: 5401177892014260120}
+  - {fileID: 1513971002868664762}
+  - {fileID: 3002973429639353596}
+  - {fileID: 4130797053091356211}
+  - {fileID: 2777644553619713434}
+  - {fileID: 1182794406674325648}
+  - {fileID: 555445455075024698}
+  - {fileID: 9070776213996443112}
+  - {fileID: 6803316941588246891}
+  - {fileID: 3659073604857985804}
+  - {fileID: 1028676496053405592}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2042359675332966308
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7305426538347102626}
+  m_Layer: 0
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7305426538347102626
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2042359675332966308}
+  m_LocalRotation: {x: -0, y: -0.70710665, z: 0, w: 0.70710695}
+  m_LocalPosition: {x: 11.07, y: 0.91418445, z: 25.422882}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8910457406479072814}
+  - {fileID: 6823081904141606672}
+  - {fileID: 5133871001999132608}
+  - {fileID: 7921772490414032259}
+  - {fileID: 4576539619927246626}
+  - {fileID: 8309709676914415237}
+  - {fileID: 7123899281970769608}
+  - {fileID: 8001099652326237819}
+  - {fileID: 32156158712322264}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3023260078106294145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5422283760990557271}
+  m_Layer: 0
+  m_Name: GameObject (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5422283760990557271
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3023260078106294145}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0.0000019669533}
+  m_LocalPosition: {x: -5.14, y: 2.0413547, z: 6.39}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3973426386450748860}
+  - {fileID: 4784496613589000647}
+  - {fileID: 8608249532848005217}
+  - {fileID: 6119066664088417236}
+  - {fileID: 449653719811264176}
+  - {fileID: 436907164123732669}
+  - {fileID: 5693949937214520633}
+  - {fileID: 6839382843484273108}
+  - {fileID: 4833935670284128391}
+  - {fileID: 8008092239107166040}
+  - {fileID: 9029929132328650546}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 0}
+--- !u!1 &3095436513847972091
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6716594060560630251}
+  m_Layer: 0
+  m_Name: GameObject (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6716594060560630251
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3095436513847972091}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0.0000019669533}
+  m_LocalPosition: {x: -5.14, y: 2.0413547, z: 1.62}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4160336681255713189}
+  - {fileID: 6726392672841473048}
+  - {fileID: 6636097796247267202}
+  - {fileID: 3275465343917837678}
+  - {fileID: 7223904830199853530}
+  - {fileID: 3561577954317376157}
+  - {fileID: 6533188881870199566}
+  - {fileID: 2313992242543955259}
+  - {fileID: 4310760024693140466}
+  - {fileID: 5222627942980738547}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 0}
+--- !u!1 &3581180132860096021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8375259592368238819}
+  m_Layer: 0
+  m_Name: GameObject (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8375259592368238819
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3581180132860096021}
+  m_LocalRotation: {x: -0, y: -0.70710665, z: 0, w: 0.70710695}
+  m_LocalPosition: {x: 9.7, y: 2.0413547, z: 25.969376}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1482179526087221747}
+  - {fileID: 1964144555999663369}
+  - {fileID: 5021698535409886462}
+  - {fileID: 7141713345396394075}
+  - {fileID: 2145525164050019808}
+  - {fileID: 7352482083455166305}
+  - {fileID: 7221371809914144159}
+  - {fileID: 6242460650565301269}
+  - {fileID: 4871810381009992301}
+  - {fileID: 6596947319902571374}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5401022219619027322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8628492153223619133}
+  m_Layer: 0
+  m_Name: Walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8628492153223619133
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5401022219619027322}
+  m_LocalRotation: {x: -0, y: 0.0000002682209, z: -0, w: 1}
+  m_LocalPosition: {x: 0.3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1955001306454451210}
+  - {fileID: 8479476526261307480}
+  - {fileID: 7146884771423746798}
+  - {fileID: 9077133035559362323}
+  - {fileID: 1461274011888953316}
+  - {fileID: 3708085673556497049}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5856777404161568065
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1357254472138268642}
+  m_Layer: 0
+  m_Name: GameObject (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1357254472138268642
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5856777404161568065}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0.0000019669533}
+  m_LocalPosition: {x: -11.02, y: 2.0413547, z: 1.62}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7087443412720342354}
+  - {fileID: 6760085276765943098}
+  - {fileID: 6684999223031300810}
+  - {fileID: 3304043497234461692}
+  - {fileID: 2218345479221362663}
+  - {fileID: 5370453683893635559}
+  - {fileID: 2251925871877339084}
+  - {fileID: 6869005239785271240}
+  - {fileID: 8964408315739603328}
+  - {fileID: 2562274429805257389}
+  - {fileID: 177110444871517364}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 0}
+--- !u!1 &7104717311803946632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3261112217613819774}
+  m_Layer: 0
+  m_Name: JournalRoom_HH
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!4 &3261112217613819774
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7104717311803946632}
+  m_LocalRotation: {x: -0, y: 0.70710665, z: -0, w: 0.70710695}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8628492153223619133}
+  - {fileID: 913600539750437975}
+  - {fileID: 7305426538347102626}
+  - {fileID: 8375259592368238819}
+  - {fileID: 202351300519877863}
+  - {fileID: 1357254472138268642}
+  - {fileID: 5422283760990557271}
+  - {fileID: 6716594060560630251}
+  - {fileID: 8796026894415765135}
+  - {fileID: 6283498614875764126}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 90, z: 0}
+--- !u!1 &8277095085025616788
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8796026894415765135}
+  m_Layer: 0
+  m_Name: Lights
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8796026894415765135
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8277095085025616788}
+  m_LocalRotation: {x: -0, y: -0.70710665, z: 0, w: 0.70710695}
+  m_LocalPosition: {x: 3.6234376, y: -0.7670783, z: 8.466284}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1044268577337541773}
+  - {fileID: 22194966448572990}
+  - {fileID: 3634520483929597456}
+  - {fileID: 5648998905242723370}
+  - {fileID: 365880950230721793}
+  - {fileID: 5516600720815049227}
+  - {fileID: 604754929191685331}
+  - {fileID: 6256408577519413003}
+  m_Father: {fileID: 3261112217613819774}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &25576442023513206
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.144
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &2795048111786262256 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 25576442023513206}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &121557772815435472
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.12800026
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.366
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.249
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6438411
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.76515925
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -99.842
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &2675521313857906891 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 121557772815435472}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &127151588493839998
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6437855
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.998997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.044779386
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &2687870393685631077 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 127151588493839998}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &144868708478321537
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.3409996
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.409
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7693551
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6388213
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (10)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &2777644553619713434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 144868708478321537}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &329453252627211040
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6437855
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.998997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.044779386
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &2313992242543955259 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 329453252627211040}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &443426722359445604
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.80599976
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.366
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.259
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.67828065
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.734803
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &2497771640717321855 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 443426722359445604}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &504833442395802806
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.841
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (21)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &2562274429805257389 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 504833442395802806}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &672393545524436455
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709374
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.5877857
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990871
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04271927
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &3304043497234461692 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 672393545524436455}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &693938241740282869
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8628492153223619133}
+    m_Modifications:
+    - target: {fileID: 109861664846363845, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_Name
+      value: WallYDoor_HH
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.050002
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.65999985
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8041323651063651266, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8257698927918845673}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+--- !u!4 &1955001306454451210 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1333296885298462719, guid: 0868872c032118c49a56ac0a3242a273, type: 3}
+  m_PrefabInstance: {fileID: 693938241740282869}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &718968676299432821
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709374
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.5877857
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990871
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04271927
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &3275465343917837678 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 718968676299432821}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &946376319551257319
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.6502428
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.409
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.258024
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6747338
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7380612
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &3002973429639353596 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 946376319551257319}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1191040865253464594
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.8393755
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3106453
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.1222143
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.13052633
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9914448
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -285
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038148966630145050, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_Name
+      value: BoxB (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+--- !u!4 &1559515457587117234 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+  m_PrefabInstance: {fileID: 1191040865253464594}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1465773102986824074
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.026000023
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.000027000904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &3659073604857985804 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 1465773102986824074}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1656969337080736564
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 5853425356224166789, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_Name
+      value: Candle_02
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.511729
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.7670785
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.0375614
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+--- !u!4 &5516600720815049227 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6516809772383150399, guid: 81951d49b45c58e44b247d3f595dfd63, type: 3}
+  m_PrefabInstance: {fileID: 1656969337080736564}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1728705602440947739
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0987854
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &3561577954317376157 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 1728705602440947739}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1949393273246542137
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.1999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.1999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.142885
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.42418444
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.376073
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9962953
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.08599866
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -80.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (11)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &4576539619927246626 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 1949393273246542137}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2041377897244994672
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8628492153223619133}
+    m_Modifications:
+    - target: {fileID: 3064727835192536343, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_Name
+      value: InSideWallX_HH
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 10.620002
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.790005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+--- !u!4 &9077133035559362323 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+  m_PrefabInstance: {fileID: 2041377897244994672}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2124044712973099886
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1955001306454451210}
+    m_Modifications:
+    - target: {fileID: 7253314008848316221, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_Name
+      value: Column_01 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2059934
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 4.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.89
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7073659
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7068477
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.958
+      objectReference: {fileID: 0}
+    - target: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+--- !u!4 &8257698927918845673 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8062325166408265095, guid: d28aee3f0237e4c44bf45ffae0d64026, type: 3}
+  m_PrefabInstance: {fileID: 2124044712973099886}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2151887584213282856
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.2259998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.409
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.258001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6747339
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.73806125
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (9)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &4130797053091356211 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 2151887584213282856}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2189282964213167017
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.8393755
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3106453
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.1222143
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.13052633
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9914448
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -285
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038148966630145050, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_Name
+      value: BoxB (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+--- !u!4 &1964144555999663369 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+  m_PrefabInstance: {fileID: 2189282964213167017}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2208514950846855037
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.749375
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.1013546
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.91378593
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999926
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.003857553
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &7087443412720342354 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 2208514950846855037}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2255170727843459156
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 1230599465515225071, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_Name
+      value: Candle_01
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.457687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.7670783
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.0929885
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+--- !u!4 &365880950230721793 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1898310249390167381, guid: b8991699bf60e70469f60901c1c88e01, type: 3}
+  m_PrefabInstance: {fileID: 2255170727843459156}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2259792390517638633
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.24621487
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &4310760024693140466 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 2259792390517638633}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2342126968648001595
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.9432144
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &436907164123732669 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 2342126968648001595}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2500621489249591467
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709374
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.5877857
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990871
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04271927
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &449653719811264176 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 2500621489249591467}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2538859077631258913
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.6502428
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.454
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.258024
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6747338
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7380612
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (16)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &555445455075024698 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 2538859077631258913}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2701528772817484075
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.9432144
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &282916207110327213 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 2701528772817484075}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2809042550167612079
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.288
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (22)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &177110444871517364 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 2809042550167612079}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2942621883532965150
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.9709997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.000027000904
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &1028676496053405592 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 2942621883532965150}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3213424724872522915
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 8142659977204191506, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_Name
+      value: Candle_03 (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.317247
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.7670783
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -3.7687702
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+--- !u!4 &6256408577519413003 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+  m_PrefabInstance: {fileID: 3213424724872522915}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3570286642274772897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.1999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.1999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.5895481
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.409
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.279091
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.76529753
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.64367676
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -80.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &1513971002868664762 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 3570286642274772897}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3759973680066310018
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 8142659977204191506, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_Name
+      value: Candle_03 (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.889184
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.7670783
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.6951647
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+--- !u!4 &5648998905242723370 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+  m_PrefabInstance: {fileID: 3759973680066310018}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3811348673732988555
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.1999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.1999998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.5895481
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.454
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.279091
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.76529753
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.64367676
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -80.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (15)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &1182794406674325648 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 3811348673732988555}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4060551023337295201
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.9432144
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &2218345479221362663 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4060551023337295201}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4166021484286428490
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0897856
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &2251925871877339084 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4166021484286428490}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4275801801016969062
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.9432144
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &2145525164050019808 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4275801801016969062}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4376728893962685365
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0987854
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &1886339109012568371 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4376728893962685365}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4654927261375370727
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.04778576
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &7352482083455166305 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4654927261375370727}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4687786698260799974
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.6982996
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.6983
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.6982996
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.182595
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.6413547
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.235052
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.28684488
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.9579771
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 33.339
+      objectReference: {fileID: 0}
+    - target: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 585608503358036635, guid: 50c00682321929e4d96c981f76022502, type: 3}
+      propertyPath: m_Name
+      value: Skull_Bone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 50c00682321929e4d96c981f76022502, type: 3}
+--- !u!4 &4784496613589000647 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 246483536141008929, guid: 50c00682321929e4d96c981f76022502, type: 3}
+  m_PrefabInstance: {fileID: 4687786698260799974}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4802996330294720281
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.0987854
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &7221371809914144159 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4802996330294720281}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4814537095429292892
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.9432144
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &7223904830199853530 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 4814537095429292892}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4990530126165531530
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.749375
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.1013546
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.91378593
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999926
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.003857553
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &4160336681255713189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 4990530126165531530}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5047402371384010641
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3261112217613819774}
+    m_Modifications:
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.736
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.772
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.775
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.70710695
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.70710665
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5339976490933752994, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+      propertyPath: m_Name
+      value: JournalPiece
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+--- !u!4 &6283498614875764126 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1240883551765451279, guid: 1fb40e1119ed7be4abee4f384d2d9b5e, type: 3}
+  m_PrefabInstance: {fileID: 5047402371384010641}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5067584172992856275
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.162884
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.42418444
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.556073
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.998997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.044779386
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (13)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &7123899281970769608 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 5067584172992856275}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5157455144369153600
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709374
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.5877857
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990871
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04271927
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &7141713345396394075 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 5157455144369153600}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5170527613371491076
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.2915448
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.2915448
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.2915448
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.4752822
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.1850781
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.349663
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5531667053440889728, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_Name
+      value: Candle_06 (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+--- !u!4 &22194966448572990 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+  m_PrefabInstance: {fileID: 5170527613371491076}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5204810594011229624
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 8142659977204191506, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_Name
+      value: Candle_03
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.344116
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.1820784
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.235444
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+--- !u!4 &3634520483929597456 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+  m_PrefabInstance: {fileID: 5204810594011229624}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5310493449185721822
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.17
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (4)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &8008092239107166040 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 5310493449185721822}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5328393812759653815
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.2915448
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.2915448
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.2915448
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.8639822
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.1850781
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.0331626
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5531667053440889728, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+      propertyPath: m_Name
+      value: Candle_06
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+--- !u!4 &1044268577337541773 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5156548232790354234, guid: 18313bb932cbe4746b819992c595d925, type: 3}
+  m_PrefabInstance: {fileID: 5328393812759653815}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5440091933049124613
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.352884
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4868156
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.7340736
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &7921772490414032259 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 5440091933049124613}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5442351583214864480
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.142884
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.42418444
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.4360733
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (14)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &8001099652326237819 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 5442351583214864480}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5465648804767397779
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.749375
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.1013546
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.91378593
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999926
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.003857553
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &3973426386450748860 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 5465648804767397779}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5591575103954308509
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.5799999
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.352
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.127
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.7933533
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6087615
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -285
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038148966630145050, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_Name
+      value: BoxB
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+--- !u!4 &5240692152236813117 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+  m_PrefabInstance: {fileID: 5591575103954308509}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5858138757069503188
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.34221458
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.039967563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &8485567275623371983 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 5858138757069503188}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5970047151473517050
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8628492153223619133}
+    m_Modifications:
+    - target: {fileID: 3064727835192536343, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_Name
+      value: InSideWallX_HH (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.83000004
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.790005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+--- !u!4 &3708085673556497049 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+  m_PrefabInstance: {fileID: 5970047151473517050}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6331081133227948190
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.162884
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.42418444
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.4360733
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9989969
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.044779446
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (12)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &8309709676914415237 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 6331081133227948190}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6375720689921194680
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.8393755
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3106453
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.1222143
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.13052633
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9914448
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -285
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038148966630145050, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_Name
+      value: BoxB (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+--- !u!4 &6726392672841473048 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+  m_PrefabInstance: {fileID: 6375720689921194680}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6409550183031804826
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.8393755
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3106453
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.1222143
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.13052633
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9914448
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -285
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038148966630145050, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_Name
+      value: BoxB (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+--- !u!4 &6760085276765943098 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+  m_PrefabInstance: {fileID: 6409550183031804826}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6435572089964823396
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.24621487
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &9061593074721041791 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 6435572089964823396}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6444473752153799667
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.2259998
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.454
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.258001
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.6747339
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.73806125
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (17)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &9070776213996443112 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 6444473752153799667}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6475684678949939497
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.51
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (21)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &9029929132328650546 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 6475684678949939497}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6554748532194865926
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.823
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &8964408315739603328 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 6554748532194865926}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6856393564734640181
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.162884
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.4518156
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.496073
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.039967563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &8910457406479072814 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 6856393564734640181}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7007082488200825573
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.34221458
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.039967563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &5021698535409886462 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 7007082488200825573}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7039109348166808902
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.352885
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.4868156
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 7.369073
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &5133871001999132608 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 7039109348166808902}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7427181156238333046
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6437855
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.998997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.044779386
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &4871810381009992301 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 7427181156238333046}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7434867435704481703
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8628492153223619133}
+    m_Modifications:
+    - target: {fileID: 109861664846363845, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_Name
+      value: InSideWallY_HH
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.188
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+--- !u!4 &8479476526261307480 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+  m_PrefabInstance: {fileID: 7434867435704481703}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7465585763728932508
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.24621487
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &4833935670284128391 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 7465585763728932508}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7524480281923044316
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.749375
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.1013546
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.91378593
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999926
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.003857553
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &1482179526087221747 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 7524480281923044316}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7589440169911336120
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.5500002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.059999943
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.29
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7098294
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7043737
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &1562338959723880087 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 7589440169911336120}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7591782568207308701
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.04778576
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &5749885974107956507 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 7591782568207308701}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7607747028064145343
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.04778576
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &5693949937214520633 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 7607747028064145343}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7788821600075283297
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.04778576
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &5370453683893635559 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 7788821600075283297}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7960770944397824387
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.1289997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.366
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.255
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7366685
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.67625403
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &5401177892014260120 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 7960770944397824387}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7992302331442900853
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.35964537
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.91
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (3)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &5222627942980738547 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 7992302331442900853}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8084366169865651859
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0897856
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &6242460650565301269 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 8084366169865651859}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8099102594435784143
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.34221458
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.039967563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6119066664088417236 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8099102594435784143}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8191493184178947345
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8628492153223619133}
+    m_Modifications:
+    - target: {fileID: 109861664846363845, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_Name
+      value: InSideWallY_HH (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.050002
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 11.010002
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+--- !u!4 &7146884771423746798 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1333296885298462719, guid: e2affe5c2d976bf41a24ad67e112139a, type: 3}
+  m_PrefabInstance: {fileID: 8191493184178947345}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8198732210275086645
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709374
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.5877857
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990871
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04271927
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (8)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6145513338921639726 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8198732210275086645}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8228041130757359483
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8796026894415765135}
+    m_Modifications:
+    - target: {fileID: 8142659977204191506, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_Name
+      value: Candle_03 (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -9.951658
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.7670783
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.3536177
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+--- !u!4 &604754929191685331 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8812236838287412136, guid: f06e8bed5e1fe6d49873517ecc4e7da4, type: 3}
+  m_PrefabInstance: {fileID: 8228041130757359483}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8238573590909159105
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2021
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.8393755
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3106453
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 1.1222143
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.13052633
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9914448
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -285
+      objectReference: {fileID: 0}
+    - target: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1038148966630145050, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+      propertyPath: m_Name
+      value: BoxB (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+--- !u!4 &8608249532848005217 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 370401623909721760, guid: 6642c8d0c2b255545b87d2b88653df13, type: 3}
+  m_PrefabInstance: {fileID: 8238573590909159105}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8496998364360152199
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8628492153223619133}
+    m_Modifications:
+    - target: {fileID: 3064727835192536343, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_Name
+      value: InSideWallX_HH (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.820001
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 17.790005
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+--- !u!4 &1461274011888953316 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7038028934820508515, guid: bce98d8ede7957048b74af36d95dfaee, type: 3}
+  m_PrefabInstance: {fileID: 8496998364360152199}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8668130811224894673
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.34221458
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.039967563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6684999223031300810 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8668130811224894673}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8689316813629327769
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.3246453
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.34221458
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999201
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.039967563
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -94.581
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (6)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6636097796247267202 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8689316813629327769}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8808746771387199755
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.162884
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.4518156
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 4.5660734
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9990871
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.04271927
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -85.103
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (5)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6823081904141606672 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8808746771387199755}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8819418226260793295
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5422283760990557271}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000008
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.709375
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6437855
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.998997
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.044779386
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -95.133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (19)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6839382843484273108 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8819418226260793295}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8855410461683031920
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 913600539750437975}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2000003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.3409996
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.454
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7693551
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.6388213
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (18)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6803316941588246891 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8855410461683031920}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8887700875608506814
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 202351300519877863}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.749375
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.1013546
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.91378593
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999926
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.003857553
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &552504890823254929 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 8887700875608506814}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8925320328328249811
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1357254472138268642}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.24621487
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6869005239785271240 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 8925320328328249811}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8951555711015119240
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6716594060560630251}
+    m_Modifications:
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5724987
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.899376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.61235464
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.0897856
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.707126
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7070876
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -0.003
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3304248482733959228, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+      propertyPath: m_Name
+      value: Cardboard_Box_02 (7)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+--- !u!4 &6533188881870199566 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2778963762916061830, guid: 34a6f1e778ae8194fa997fed05b10004, type: 3}
+  m_PrefabInstance: {fileID: 8951555711015119240}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8975583094301981431
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7305426538347102626}
+    m_Modifications:
+    - target: {fileID: 8626152722855180437, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_Name
+      value: RackB (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2229002
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2229004
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.162884
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.9741844
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 5.246071
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9999926
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.003857553
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -89.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+--- !u!4 &32156158712322264 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9006513838672929327, guid: 441dcd7d1b0885d408e586232dc28413, type: 3}
+  m_PrefabInstance: {fileID: 8975583094301981431}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &9152318233681110389
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8375259592368238819}
+    m_Modifications:
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_RootOrder
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 2.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.689376
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.5713546
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.24621487
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9957312
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.09230114
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -79.408
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3442246548414985377, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+      propertyPath: m_Name
+      value: BoxA (20)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+--- !u!4 &6596947319902571374 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2634183929806368283, guid: 5353f6717b6e8284198a3842f7324b6f, type: 3}
+  m_PrefabInstance: {fileID: 9152318233681110389}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefab/Stage/HorrorHouse/JournalRoom_HH.prefab.meta
+++ b/Assets/Resources/Prefab/Stage/HorrorHouse/JournalRoom_HH.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eeba671f4abdc4442abd6a7d33463b2f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefab/Stage/JournalPiece.prefab
+++ b/Assets/Resources/Prefab/Stage/JournalPiece.prefab
@@ -1,0 +1,107 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5339976490933752994
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1240883551765451279}
+  - component: {fileID: 2902841256724779529}
+  - component: {fileID: 6382383664686753935}
+  - component: {fileID: 7593220476925732972}
+  m_Layer: 0
+  m_Name: JournalPiece
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1240883551765451279
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5339976490933752994}
+  m_LocalRotation: {x: -0, y: -0.70710665, z: 0, w: 0.70710695}
+  m_LocalPosition: {x: 7.736, y: 1.772, z: 6.775}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 0.7}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2902841256724779529
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5339976490933752994}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6382383664686753935
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5339976490933752994}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 257
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ffcf46ca817b5d54388e2e2f5e361c6e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &7593220476925732972
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5339976490933752994}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Resources/Prefab/Stage/JournalPiece.prefab.meta
+++ b/Assets/Resources/Prefab/Stage/JournalPiece.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1fb40e1119ed7be4abee4f384d2d9b5e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要
痕跡対応表部屋プレハブの作成
Assets/Resources/Prefab/Stage/HorrorHouse/JournalRoom_HH.prefab

痕跡対応表アイテムのプレハブの作成
Assets/Resources/Prefab/Stage/JournalPiece.prefab
## 変更点
- 上記２つのPrefabのインポート

